### PR TITLE
🐛 fix : 자동 배포중 Export로 서버 네임 지정하는 구문 에러 발생

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: export SERVER_NAME
-        run: export ${{ secrets.DEV_SERVER_NAME }}
+        run: export SERVER_NAME=${{ secrets.DEV_SERVER_NAME }}
 
       - name: OpenAPI Spec Create
         run: ./gradlew test copyDocument

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: export SERVER_NAME
-        run: export ${{ secrets.PROD_SERVER_NAME }}
+        run: export SERVER_NAME=${{ secrets.PROD_SERVER_NAME }}
 
       - name: OpenAPI Spec Create
         run: ./gradlew test copyDocument


### PR DESCRIPTION
## 작업사항

자동 배포중 상황에 맞는 서버 주소 지정을 위해 secrets에서 불러올때 "export SERVER_NAME=서버 주소" 와 같은 형태로 변경

resolved : #25 
