### PR TITLE
✨ feat : 스터디 생성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,11 @@ openapi3 {
     description = 'Checkmoi API 페이지'
     version = project.version.toString().toUpperCase()
     format = 'yaml'
+    oauth2SecuritySchemeDefinition = {
+        flows = ['authorizationCode']
+        tokenUrl = "$System.env.SERVER_NAME/token"
+        authorizationUrl = "$System.env.SERVER_NAME/authorize"
+    }
 }
 
 sonarqube {

--- a/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
@@ -1,0 +1,32 @@
+package com.devcourse.checkmoi.domain.study.api;
+
+import static com.devcourse.checkmoi.global.util.ApiUtil.generatedUri;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.CreateStudy;
+import com.devcourse.checkmoi.domain.study.service.study.StudyCommandService;
+import com.devcourse.checkmoi.global.model.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class StudyApi {
+
+    private final StudyCommandService studyCommandService;
+
+    // C 스터디 개설 #5
+    @PostMapping("/studies")
+    public ResponseEntity<SuccessResponse<Long>> createStudy(
+        @RequestBody CreateStudy request) {
+        Long studyId = studyCommandService.createStudy(request);
+        return ResponseEntity
+            .created(generatedUri(studyId))
+            .body(new SuccessResponse<>(studyId));
+    }
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
@@ -1,7 +1,7 @@
 package com.devcourse.checkmoi.domain.study.api;
 
 import static com.devcourse.checkmoi.global.util.ApiUtil.generatedUri;
-import com.devcourse.checkmoi.domain.study.dto.StudyRequest.CreateStudy;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 import com.devcourse.checkmoi.domain.study.service.study.StudyCommandService;
 import com.devcourse.checkmoi.global.model.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,10 +20,9 @@ public class StudyApi {
 
     private final StudyCommandService studyCommandService;
 
-    // C 스터디 개설 #5
     @PostMapping("/studies")
     public ResponseEntity<SuccessResponse<Long>> createStudy(
-        @RequestBody CreateStudy request) {
+        @RequestBody Create request) {
         Long studyId = studyCommandService.createStudy(request);
         return ResponseEntity
             .created(generatedUri(studyId))

--- a/src/main/java/com/devcourse/checkmoi/domain/study/converter/StudyConverter.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/converter/StudyConverter.java
@@ -1,14 +1,14 @@
 package com.devcourse.checkmoi.domain.study.converter;
 
 import com.devcourse.checkmoi.domain.book.model.Book;
-import com.devcourse.checkmoi.domain.study.dto.StudyRequest.CreateStudy;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import org.springframework.stereotype.Component;
 
 @Component
 public class StudyConverter {
 
-    public Study createToEntity(CreateStudy request) {
+    public Study createToEntity(Create request) {
         return Study.builder()
             .book(
                 Book.builder()

--- a/src/main/java/com/devcourse/checkmoi/domain/study/converter/StudyConverter.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/converter/StudyConverter.java
@@ -1,0 +1,27 @@
+package com.devcourse.checkmoi.domain.study.converter;
+
+import com.devcourse.checkmoi.domain.book.model.Book;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.CreateStudy;
+import com.devcourse.checkmoi.domain.study.model.Study;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StudyConverter {
+
+    public Study createToEntity(CreateStudy request) {
+        return Study.builder()
+            .book(
+                Book.builder()
+                    .id(request.bookId())
+                    .build()
+            )
+            .name(request.name())
+            .thumbnailUrl(request.thumbnail())
+            .description(request.description())
+            .maxParticipant(request.maxParticipant())
+            .gatherStartDate(request.gatherStartDate())
+            .gatherEndDate(request.gatherEndDate())
+            .build();
+    }
+
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyRequest.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyRequest.java
@@ -1,12 +1,12 @@
 package com.devcourse.checkmoi.domain.study.dto;
 
-import com.devcourse.checkmoi.domain.study.dto.StudyRequest.CreateStudy;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 import java.time.LocalDate;
 import lombok.Builder;
 
-public sealed interface StudyRequest permits CreateStudy {
+public sealed interface StudyRequest permits Create {
 
-    record CreateStudy(
+    record Create(
         Long bookId,
         String name,
         String thumbnail,
@@ -17,7 +17,7 @@ public sealed interface StudyRequest permits CreateStudy {
     ) implements StudyRequest {
 
         @Builder
-        public CreateStudy {
+        public Create {
         }
     }
 

--- a/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyRequest.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyRequest.java
@@ -1,0 +1,24 @@
+package com.devcourse.checkmoi.domain.study.dto;
+
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.CreateStudy;
+import java.time.LocalDate;
+import lombok.Builder;
+
+public sealed interface StudyRequest permits CreateStudy {
+
+    record CreateStudy(
+        Long bookId,
+        String name,
+        String thumbnail,
+        String description,
+        Integer maxParticipant,
+        LocalDate gatherStartDate,
+        LocalDate gatherEndDate
+    ) implements StudyRequest {
+
+        @Builder
+        public CreateStudy {
+        }
+    }
+
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/Study.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/Study.java
@@ -12,6 +12,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -43,5 +44,36 @@ public class Study extends BaseEntity {
     private LocalDate studyStartDate;
 
     private LocalDate studyEndDate;
+
+    public Study(String name, String thumbnailUrl, String description, Integer maxParticipant,
+        Book book, LocalDate gatherStartDate, LocalDate gatherEndDate,
+        LocalDate studyStartDate, LocalDate studyEndDate) {
+        this(null, name, thumbnailUrl, description, maxParticipant, book, gatherStartDate,
+            gatherEndDate, studyStartDate, studyEndDate);
+    }
+
+    @Builder
+    public Study(Long id, String name, String thumbnailUrl, String description,
+        Integer maxParticipant, Book book, LocalDate gatherStartDate, LocalDate gatherEndDate,
+        LocalDate studyStartDate, LocalDate studyEndDate) {
+        this.id = id;
+        this.name = name;
+        this.thumbnailUrl = thumbnailUrl;
+        this.description = description;
+        this.maxParticipant = maxParticipant;
+        this.book = book;
+        this.gatherStartDate = gatherStartDate;
+        this.gatherEndDate = gatherEndDate;
+        this.studyStartDate = studyStartDate;
+        this.studyEndDate = studyEndDate;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Book getBook() {
+        return book;
+    }
 
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/StudyRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/StudyRepository.java
@@ -1,0 +1,8 @@
+package com.devcourse.checkmoi.domain.study.repository.study;
+
+import com.devcourse.checkmoi.domain.study.model.Study;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyRepository extends JpaRepository<Study, Long> {
+
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandService.java
@@ -1,0 +1,8 @@
+package com.devcourse.checkmoi.domain.study.service.study;
+
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.CreateStudy;
+
+public interface StudyCommandService {
+
+    Long createStudy(CreateStudy request);
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandService.java
@@ -1,8 +1,8 @@
 package com.devcourse.checkmoi.domain.study.service.study;
 
-import com.devcourse.checkmoi.domain.study.dto.StudyRequest.CreateStudy;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 
 public interface StudyCommandService {
 
-    Long createStudy(CreateStudy request);
+    Long createStudy(Create request);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImpl.java
@@ -1,0 +1,25 @@
+package com.devcourse.checkmoi.domain.study.service.study;
+
+import com.devcourse.checkmoi.domain.study.converter.StudyConverter;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.CreateStudy;
+import com.devcourse.checkmoi.domain.study.repository.study.StudyRepository;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StudyCommandServiceImpl implements
+    StudyCommandService {
+
+    private final StudyConverter studyConverter;
+
+    private final StudyRepository studyRepository;
+
+    @Override
+    public Long createStudy(CreateStudy request) {
+        return studyRepository.save(studyConverter.createToEntity(request)).getId();
+    }
+
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImpl.java
@@ -1,7 +1,7 @@
 package com.devcourse.checkmoi.domain.study.service.study;
 
 import com.devcourse.checkmoi.domain.study.converter.StudyConverter;
-import com.devcourse.checkmoi.domain.study.dto.StudyRequest.CreateStudy;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 import com.devcourse.checkmoi.domain.study.repository.study.StudyRepository;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +18,10 @@ public class StudyCommandServiceImpl implements
     private final StudyRepository studyRepository;
 
     @Override
-    public Long createStudy(CreateStudy request) {
-        return studyRepository.save(studyConverter.createToEntity(request)).getId();
+    public Long createStudy(Create request) {
+        return studyRepository
+            .save(studyConverter.createToEntity(request))
+            .getId();
     }
 
 }

--- a/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
@@ -1,0 +1,112 @@
+package com.devcourse.checkmoi.domain.study.api;
+
+import static com.devcourse.checkmoi.util.DocumentUtil.getDateFormat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest;
+import com.devcourse.checkmoi.domain.study.service.study.StudyCommandService;
+import com.devcourse.checkmoi.global.model.SuccessResponse;
+import com.devcourse.checkmoi.template.ApiTest;
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(StudyApi.class)
+class StudyApiTest extends ApiTest {
+
+    @MockBean
+    private StudyCommandService studyCommandService;
+
+    @Nested
+    @DisplayName("스터디 등록 (개설) #5")
+    class CreateStudy {
+
+        @Test
+        @WithMockUser
+        @DisplayName("S 스터디를 등록할 수 있다")
+        void createStudy() throws Exception {
+            StudyRequest.CreateStudy request = StudyRequest.CreateStudy.builder()
+                .bookId(1L)
+                .name("스터디 이름")
+                .thumbnail("스터디 썸네일 URL")
+                .description("스터디입니다")
+                .maxParticipant(5)
+                .gatherStartDate(LocalDate.now())
+                .gatherEndDate(LocalDate.now())
+                .build();
+            Long createdStudyId = 1L;
+            SuccessResponse<Long> want = new SuccessResponse<>(1L);
+
+            when(studyCommandService.createStudy(any(StudyRequest.CreateStudy.class))).thenReturn(
+                createdStudyId);
+            MvcResult result = mockMvc.perform(RestDocumentationRequestBuilders.post("/api/studies")
+                    .contentType(MediaType.APPLICATION_JSON).characterEncoding("utf-8")
+                    .content(toJson(request)))
+                .andExpect(status().isCreated())
+                .andDo(documentation())
+                .andReturn();
+
+            SuccessResponse<Long> got = objectMapper.readValue(
+                result.getResponse().getContentAsString(),
+                new TypeReference<>() {
+                }
+            );
+            then(studyCommandService).should(times(1))
+                .createStudy(any(StudyRequest.CreateStudy.class));
+            assertThat(got.data()).isEqualTo(want.data());
+        }
+
+        private RestDocumentationResultHandler documentation() {
+            return MockMvcRestDocumentationWrapper.document("study-create",
+                ResourceSnippetParameters.builder()
+                    .tag("Study API")
+                    .summary("스터디 등록")
+                    .description("스터디 등록에 사용되는 API입니다.")
+                    .requestSchema(Schema.schema("StudyRequest.CreateStudy"))
+                    .responseSchema(Schema.schema("Study ID")),
+                requestFields(
+                    fieldWithPath("bookId").type(JsonFieldType.NUMBER)
+                        .description("책 아이디"),
+                    fieldWithPath("name").type(JsonFieldType.STRING)
+                        .description("스터디 이름"),
+                    fieldWithPath("thumbnail").type(JsonFieldType.STRING)
+                        .description("스터디 썸네일"),
+                    fieldWithPath("description").type(JsonFieldType.STRING)
+                        .description("스터디 설명"),
+                    fieldWithPath("maxParticipant").type(JsonFieldType.NUMBER)
+                        .description("스터디 최대 참여 인원"),
+                    fieldWithPath("gatherStartDate").type(JsonFieldType.STRING)
+                        .attributes(getDateFormat())
+                        .description("모집 시작일자"),
+                    fieldWithPath("gatherEndDate").type(JsonFieldType.STRING)
+                        .attributes(getDateFormat())
+                        .description("모집 종료일자")
+                ),
+                responseFields(
+                    fieldWithPath("data").type(JsonFieldType.NUMBER)
+                        .description("생성된 스터디 아이디")
+                )
+            );
+        }
+    }
+}

--- a/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
@@ -39,13 +39,13 @@ class StudyApiTest extends ApiTest {
 
     @Nested
     @DisplayName("스터디 등록 (개설) #5")
-    class CreateStudy {
+    class Create {
 
         @Test
         @WithMockUser
         @DisplayName("S 스터디를 등록할 수 있다")
         void createStudy() throws Exception {
-            StudyRequest.CreateStudy request = StudyRequest.CreateStudy.builder()
+            StudyRequest.Create request = StudyRequest.Create.builder()
                 .bookId(1L)
                 .name("스터디 이름")
                 .thumbnail("스터디 썸네일 URL")
@@ -57,7 +57,7 @@ class StudyApiTest extends ApiTest {
             Long createdStudyId = 1L;
             SuccessResponse<Long> want = new SuccessResponse<>(1L);
 
-            when(studyCommandService.createStudy(any(StudyRequest.CreateStudy.class))).thenReturn(
+            when(studyCommandService.createStudy(any(StudyRequest.Create.class))).thenReturn(
                 createdStudyId);
             MvcResult result = mockMvc.perform(RestDocumentationRequestBuilders.post("/api/studies")
                     .contentType(MediaType.APPLICATION_JSON).characterEncoding("utf-8")
@@ -72,7 +72,7 @@ class StudyApiTest extends ApiTest {
                 }
             );
             then(studyCommandService).should(times(1))
-                .createStudy(any(StudyRequest.CreateStudy.class));
+                .createStudy(any(StudyRequest.Create.class));
             assertThat(got.data()).isEqualTo(want.data());
         }
 

--- a/src/test/java/com/devcourse/checkmoi/domain/study/converter/StudyConverterTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/converter/StudyConverterTest.java
@@ -15,12 +15,12 @@ class StudyConverterTest {
 
     @Nested
     @DisplayName("스터디 등록 (개설) #5")
-    class CreateStudy {
+    class Create {
 
         @Test
         @DisplayName("S 스터디 등록 요청을 엔티티로 변환할 수 있다.")
         void createToEntityTest() {
-            StudyRequest.CreateStudy request = StudyRequest.CreateStudy.builder()
+            StudyRequest.Create request = StudyRequest.Create.builder()
                 .bookId(1L)
                 .name("스터디 이름")
                 .thumbnail("스터디 썸네일 URL")

--- a/src/test/java/com/devcourse/checkmoi/domain/study/converter/StudyConverterTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/converter/StudyConverterTest.java
@@ -1,0 +1,53 @@
+package com.devcourse.checkmoi.domain.study.converter;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import com.devcourse.checkmoi.domain.book.model.Book;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest;
+import com.devcourse.checkmoi.domain.study.model.Study;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class StudyConverterTest {
+
+    private final StudyConverter studyConverter = new StudyConverter();
+
+    @Nested
+    @DisplayName("스터디 등록 (개설) #5")
+    class CreateStudy {
+
+        @Test
+        @DisplayName("S 스터디 등록 요청을 엔티티로 변환할 수 있다.")
+        void createToEntityTest() {
+            StudyRequest.CreateStudy request = StudyRequest.CreateStudy.builder()
+                .bookId(1L)
+                .name("스터디 이름")
+                .thumbnail("스터디 썸네일 URL")
+                .description("스터디입니다")
+                .maxParticipant(5)
+                .gatherStartDate(LocalDate.now())
+                .gatherEndDate(LocalDate.now())
+                .build();
+            Study want = Study.builder()
+                .book(
+                    Book.builder().
+                        id(request.bookId())
+                        .build()
+                )
+                .name(request.name())
+                .thumbnailUrl(request.thumbnail())
+                .description(request.description())
+                .maxParticipant(request.maxParticipant())
+                .gatherStartDate(request.gatherStartDate())
+                .gatherEndDate(request.gatherEndDate())
+                .build();
+
+            Study got = studyConverter.createToEntity(request);
+
+            assertThat(got)
+                .usingRecursiveComparison()
+                .isEqualTo(want);
+        }
+    }
+}

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImplTest.java
@@ -1,0 +1,74 @@
+package com.devcourse.checkmoi.domain.study.service.study;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import com.devcourse.checkmoi.domain.book.model.Book;
+import com.devcourse.checkmoi.domain.study.converter.StudyConverter;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.CreateStudy;
+import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.repository.study.StudyRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StudyCommandServiceImplTest {
+
+    @InjectMocks
+    StudyCommandServiceImpl studyCommandService;
+
+    @Mock
+    StudyConverter studyConverter;
+
+    @Mock
+    StudyRepository studyRepository;
+
+    @Nested
+    @DisplayName("스터디 등록 #5")
+    class CreateStudy {
+
+        @Test
+        @DisplayName("S 스터디를 등록할 수 있다")
+        void createStudy() {
+            StudyRequest.CreateStudy request = StudyRequest.CreateStudy.builder()
+                .bookId(1L)
+                .name("스터디 이름")
+                .thumbnail("스터디 썸네일 URL")
+                .description("스터디입니다")
+                .maxParticipant(5)
+                .gatherStartDate(LocalDate.now())
+                .gatherEndDate(LocalDate.now())
+                .build();
+            Study study = Study.builder()
+                .book(
+                    Book.builder().
+                        id(request.bookId())
+                        .build()
+                )
+                .id(1L)
+                .name(request.name())
+                .thumbnailUrl(request.thumbnail())
+                .description(request.description())
+                .maxParticipant(request.maxParticipant())
+                .gatherStartDate(request.gatherStartDate())
+                .gatherEndDate(request.gatherEndDate())
+                .build();
+            Long want = 1L;
+
+            when(studyConverter.createToEntity(any(StudyRequest.CreateStudy.class)))
+                .thenReturn(study);
+            when(studyRepository.save(any(Study.class)))
+                .thenReturn(study);
+            Long got = studyCommandService.createStudy(request);
+
+            assertThat(got).isEqualTo(want);
+        }
+    }
+}

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImplTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.when;
 import com.devcourse.checkmoi.domain.book.model.Book;
 import com.devcourse.checkmoi.domain.study.converter.StudyConverter;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest;
-import com.devcourse.checkmoi.domain.study.dto.StudyRequest.CreateStudy;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.repository.study.StudyRepository;
 import java.time.LocalDate;
@@ -32,12 +31,12 @@ class StudyCommandServiceImplTest {
 
     @Nested
     @DisplayName("스터디 등록 #5")
-    class CreateStudy {
+    class Create {
 
         @Test
         @DisplayName("S 스터디를 등록할 수 있다")
         void createStudy() {
-            StudyRequest.CreateStudy request = StudyRequest.CreateStudy.builder()
+            StudyRequest.Create request = StudyRequest.Create.builder()
                 .bookId(1L)
                 .name("스터디 이름")
                 .thumbnail("스터디 썸네일 URL")
@@ -62,7 +61,7 @@ class StudyCommandServiceImplTest {
                 .build();
             Long want = 1L;
 
-            when(studyConverter.createToEntity(any(StudyRequest.CreateStudy.class)))
+            when(studyConverter.createToEntity(any(StudyRequest.Create.class)))
                 .thenReturn(study);
             when(studyRepository.save(any(Study.class)))
                 .thenReturn(study);


### PR DESCRIPTION
## 작업사항
- 책 + 스터디 정보를 요청을 보내면 스터디를 생성해주는 API 구현 및 해당 API 필요한 기능 구현
- API, Service, Converter에 대한 테스트 코드 구현
- openapi3에 Oauth2를 인증할 수 있도록 OAuth2 인증방식과 token 서버, 인증 서버 URL 추가

다음은 해당 API의 스웨거 화면입니다. (스웨거는 https://dev.checkmoi.ga/docs/index.html 에서 확인할 수 있습니다.)

<img width="1242" alt="image" src="https://user-images.githubusercontent.com/41960243/181817531-204a7f84-f813-41e4-bcbe-785a6a9c4a67.png">

## 중점적으로 봐야할 부분
- 현재 시큐리티 설정으로 인해 API 테스트시 401 에러가 계속해서 발생하여 실제 API 테스트는 성공하지 못했습니다. (유닛테스트는 전부 완료하였습니다.) 
- Jacoco 테스트 커버리지를 충족하기 위해 일단 작성했던 내용은 제거하고 먼저, 생성에 대한 기능만 포함하도록 작성 내용을 변경하였습니다. 이전의 내용은 feat/6 브랜치에서 계속해서 확인 가능합니다.

resolves #28 
