### PR TITLE
✨ feat : 스터디 가입 승낙 및 거절

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
@@ -1,6 +1,7 @@
 package com.devcourse.checkmoi.domain.study.api;
 
 import static com.devcourse.checkmoi.global.util.ApiUtil.generatedUri;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Audit;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Edit;
 import com.devcourse.checkmoi.domain.study.service.study.StudyCommandService;
@@ -40,5 +41,18 @@ public class StudyApi {
         @AuthenticationPrincipal JwtAuthentication user) {
         return ResponseEntity.ok(
             new SuccessResponse<>(studyCommandService.editStudyInfo(studyId, user.id(), request)));
+    }
+
+    @PutMapping("/{studyId}/member/{memberId}")
+    public ResponseEntity<Void> auditStudyParticipation(
+        @PathVariable Long studyId,
+        @PathVariable Long memberId,
+        @AuthenticationPrincipal JwtAuthentication user,
+        @RequestBody Audit request
+    ) {
+        studyCommandService.auditStudyParticipation(studyId, memberId, user.id(), request);
+        return ResponseEntity
+            .noContent()
+            .build();
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyRequest.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyRequest.java
@@ -1,11 +1,12 @@
 package com.devcourse.checkmoi.domain.study.dto;
 
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Audit;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Edit;
 import java.time.LocalDate;
 import lombok.Builder;
 
-public sealed interface StudyRequest permits Create, Edit {
+public sealed interface StudyRequest permits Create, Edit, Audit {
 
     record Create(
         Long bookId,
@@ -30,6 +31,16 @@ public sealed interface StudyRequest permits Create, Edit {
 
         @Builder
         public Edit {
+        }
+    }
+
+    record Audit(
+        String status
+    ) implements StudyRequest {
+
+        @Builder
+        public Audit {
+
         }
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/exception/StudyJoinRequestNotFoundException.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/exception/StudyJoinRequestNotFoundException.java
@@ -1,0 +1,12 @@
+package com.devcourse.checkmoi.domain.study.exception;
+
+import com.devcourse.checkmoi.global.exception.EntityNotFoundException;
+import com.devcourse.checkmoi.global.exception.ErrorMessage;
+
+public class StudyJoinRequestNotFoundException extends EntityNotFoundException {
+
+    public StudyJoinRequestNotFoundException(
+        ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyMember.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyMember.java
@@ -38,6 +38,14 @@ public class StudyMember {
         this.study = study;
     }
 
+    public void changeStatus(StudyMemberStatus status) {
+        this.status = status;
+    }
+
+    public StudyMemberStatus getStatus() {
+        return status;
+    }
+
     public User getUser() {
         return user;
     }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandService.java
@@ -1,5 +1,6 @@
 package com.devcourse.checkmoi.domain.study.service.study;
 
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Audit;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Edit;
 
@@ -8,4 +9,6 @@ public interface StudyCommandService {
     Long createStudy(Create request);
 
     Long editStudyInfo(Long studyId, Long userId, Edit request);
+
+    void auditStudyParticipation(Long studyId, Long memberId, Long userId, Audit request);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImpl.java
@@ -1,12 +1,18 @@
 package com.devcourse.checkmoi.domain.study.service.study;
 
 import static com.devcourse.checkmoi.global.exception.ErrorMessage.ACCESS_DENIED;
+import static com.devcourse.checkmoi.global.exception.ErrorMessage.STUDY_JOIN_REQUEST_NOT_FOUND;
 import com.devcourse.checkmoi.domain.study.converter.StudyConverter;
+import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Audit;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Edit;
 import com.devcourse.checkmoi.domain.study.exception.NotStudyOwnerException;
+import com.devcourse.checkmoi.domain.study.exception.StudyJoinRequestNotFoundException;
 import com.devcourse.checkmoi.domain.study.exception.StudyNotFoundException;
 import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
+import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import com.devcourse.checkmoi.domain.study.repository.study.StudyMemberRepository;
 import com.devcourse.checkmoi.domain.study.repository.study.StudyRepository;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +27,8 @@ public class StudyCommandServiceImpl implements StudyCommandService {
 
     private final StudyRepository studyRepository;
 
+    private final StudyMemberRepository studyMemberRepository;
+
     @Override
     public Long createStudy(Create request) {
         return studyRepository
@@ -30,8 +38,10 @@ public class StudyCommandServiceImpl implements StudyCommandService {
 
     @Override
     public Long editStudyInfo(Long studyId, Long userId, Edit request) {
+        validateExistStudy(studyRepository.existsById(studyId));
         Long studyOwnerId = studyRepository.findStudyOwner(studyId);
-        validateStudyOwner(userId, studyOwnerId);
+        validateStudyOwner(userId, studyOwnerId,
+            "스터디 정보 수정 권한이 없습니다. 유저 Id : " + userId + " 스터디장 Id : " + studyOwnerId);
         Study study = studyRepository.findById(studyId)
             .orElseThrow(StudyNotFoundException::new);
         study.editName(request.name());
@@ -40,10 +50,28 @@ public class StudyCommandServiceImpl implements StudyCommandService {
         return study.getId();
     }
 
-    private void validateStudyOwner(Long userId, Long studyOwnerId) {
-        if (!studyOwnerId.equals(userId)) {
-            throw new NotStudyOwnerException(
-                "스터디 정보 수정 권한이 없습니다. 유저 아이디 : " + userId + " 스터디장 Id : " + studyOwnerId, ACCESS_DENIED);
+    @Override
+    public void auditStudyParticipation(Long studyId, Long memberId, Long userId, Audit request) {
+        validateExistStudy(studyRepository.existsById(studyId));
+        Long studyOwnerId = studyRepository.findStudyOwner(studyId);
+        validateStudyOwner(userId, studyOwnerId,
+            "스터디 승인 권한이 없습니다. 유저 Id : " + userId + " 스터디 장 Id : " + studyOwnerId
+        );
+        StudyMember studyMember = studyMemberRepository.findById(memberId)
+            .orElseThrow(() -> new StudyJoinRequestNotFoundException(STUDY_JOIN_REQUEST_NOT_FOUND));
+        studyMember.changeStatus(StudyMemberStatus.valueOf(request.status()));
+    }
+
+    private void validateExistStudy(boolean existStudy) {
+        if (!existStudy) {
+            throw new StudyNotFoundException();
         }
     }
+
+    private void validateStudyOwner(Long userId, Long studyOwnerId, String message) {
+        if (!studyOwnerId.equals(userId)) {
+            throw new NotStudyOwnerException(message, ACCESS_DENIED);
+        }
+    }
+
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImpl.java
@@ -38,7 +38,6 @@ public class StudyCommandServiceImpl implements StudyCommandService {
 
     @Override
     public Long editStudyInfo(Long studyId, Long userId, Edit request) {
-        validateExistStudy(studyRepository.existsById(studyId));
         Long studyOwnerId = studyRepository.findStudyOwner(studyId);
         validateStudyOwner(userId, studyOwnerId,
             "스터디 정보 수정 권한이 없습니다. 유저 Id : " + userId + " 스터디장 Id : " + studyOwnerId);

--- a/src/main/java/com/devcourse/checkmoi/global/exception/ErrorMessage.java
+++ b/src/main/java/com/devcourse/checkmoi/global/exception/ErrorMessage.java
@@ -18,8 +18,8 @@ public enum ErrorMessage {
 
     // not found error
     STUDY_NOT_FOUND("해당하는 스터디를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
-    BOOK_NOT_FOUND("해당하는 책을 찾을 수 없습니다", HttpStatus.NOT_FOUND);
-
+    BOOK_NOT_FOUND("해당하는 책을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    STUDY_JOIN_REQUEST_NOT_FOUND("해당하는 스터디 가입 요청을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String message;
 

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImplTest.java
@@ -102,8 +102,6 @@ class StudyCommandServiceImplTest {
             Study study = Study.builder()
                 .id(1L)
                 .build();
-            when(studyRepository.existsById(anyLong()))
-                .thenReturn(true);
             when(studyRepository.findStudyOwner(anyLong()))
                 .thenReturn(userId);
             when(studyRepository.findById(studyId))
@@ -112,25 +110,6 @@ class StudyCommandServiceImplTest {
             Long got = studyCommandService.editStudyInfo(studyId, userId, request);
 
             assertThat(got).isEqualTo(studyId);
-        }
-
-        @Test
-        @DisplayName("F 존재하지 않는 스터디 ID일 경우 예외가 발생한다.")
-        void validateExistStudy() {
-            StudyRequest.Edit request = StudyRequest.Edit.builder()
-                .name("스터디 이름")
-                .thumbnail("https://example.com")
-                .description("스터디 설명")
-                .build();
-            Long userId = 1L;
-            Long studyId = 1L;
-
-            when(studyRepository.existsById(anyLong()))
-                .thenReturn(false);
-
-            assertThatExceptionOfType(StudyNotFoundException.class)
-                .isThrownBy(
-                    () -> studyCommandService.editStudyInfo(studyId, userId, request));
         }
 
         @Test
@@ -148,8 +127,6 @@ class StudyCommandServiceImplTest {
                 .id(1L)
                 .build();
 
-            when(studyRepository.existsById(anyLong()))
-                .thenReturn(true);
             when(studyRepository.findStudyOwner(anyLong()))
                 .thenThrow(new NotStudyOwnerException(
                     "스터디 정보 수정 권한이 없습니다. 유저 아이디 : " + userId + " 스터디장 Id : " + studyOwnerId,
@@ -174,8 +151,6 @@ class StudyCommandServiceImplTest {
             Study study = Study.builder()
                 .id(1L)
                 .build();
-            when(studyRepository.existsById(anyLong()))
-                .thenReturn(true);
             when(studyRepository.findStudyOwner(anyLong()))
                 .thenReturn(userId);
             when(studyRepository.findById(studyId))


### PR DESCRIPTION
## 작업사항

- 스터디 가입 승낙 및 거절 기능 구현
- 해당 기능이 단순한 상태변경만 제공하면 된다고 판단해 응답으로 204를 보내도록 처리했습니다.
- 스터디 존재 여부와 스터디 신청 여부 존재 확인 로직 구현 및 Exception 추가
- 상태변경에 대한 DTO 추가
- 테스트 코드 추가 및 API 문서화 추가
- 스터디 검증 로직 추가로 인한 스터디 정보 수정 기능에 해당 로직 적용

해당 API에 대한 정보입니다.
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/41960243/182023105-4b9471ba-beba-402e-876b-ac5228b184f0.png">

## 중점적으로 봐야할 부분

resolves #37 
