### PR TITLE
✨ feat : 특정 책에 대한 스터디 목록 조회 

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
@@ -4,18 +4,24 @@ import static com.devcourse.checkmoi.global.util.ApiUtil.generatedUri;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Audit;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Edit;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
 import com.devcourse.checkmoi.domain.study.service.study.StudyCommandService;
+import com.devcourse.checkmoi.domain.study.service.study.StudyQueryService;
+import com.devcourse.checkmoi.global.model.PageRequest;
 import com.devcourse.checkmoi.global.model.SuccessResponse;
 import com.devcourse.checkmoi.global.security.jwt.JwtAuthentication;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Validated
@@ -25,6 +31,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class StudyApi {
 
     private final StudyCommandService studyCommandService;
+
+    private final StudyQueryService studyQueryService;
 
     @PostMapping
     public ResponseEntity<SuccessResponse<Long>> createStudy(
@@ -55,4 +63,15 @@ public class StudyApi {
             .noContent()
             .build();
     }
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<Studies>> getStudies(
+        @RequestParam Long bookId,
+        PageRequest pageRequest
+    ) {
+        Pageable pageable = pageRequest.of();
+        Studies response = studyQueryService.getStudies(bookId, pageable);
+        return ResponseEntity.ok(new SuccessResponse<>(response));
+    }
+
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/converter/StudyConverter.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/converter/StudyConverter.java
@@ -2,6 +2,7 @@ package com.devcourse.checkmoi.domain.study.converter;
 
 import com.devcourse.checkmoi.domain.book.model.Book;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import org.springframework.stereotype.Component;
 
@@ -24,4 +25,18 @@ public class StudyConverter {
             .build();
     }
 
+    public StudyInfo studyToStudyInfo(Study study) {
+        return StudyInfo.builder()
+            .id(study.getId())
+            .name(study.getName())
+            .thumbnailUrl(study.getThumbnailUrl())
+            .description(study.getDescription())
+            .currentParticipant(study.getCurrentParticipant())
+            .maxParticipant(study.getMaxParticipant())
+            .gatherStartDate(study.getGatherStartDate())
+            .gatherEndDate(study.getGatherEndDate())
+            .studyStartDate(study.getStudyStartDate())
+            .studyEndDate(study.getStudyEndDate())
+            .build();
+    }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyResponse.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyResponse.java
@@ -1,0 +1,41 @@
+package com.devcourse.checkmoi.domain.study.dto;
+
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+public sealed interface StudyResponse permits StudyInfo, Studies {
+
+    record StudyInfo(
+        Long id,
+        String name,
+        String thumbnailUrl,
+        String description,
+        int currentParticipant,
+        Integer maxParticipant,
+        LocalDate gatherStartDate,
+        LocalDate gatherEndDate,
+        LocalDate studyStartDate,
+        LocalDate studyEndDate
+    ) implements StudyResponse {
+
+        @Builder
+        public StudyInfo {
+
+        }
+    }
+
+    record Studies(
+        Page<StudyInfo> studies
+    ) implements StudyResponse {
+
+        @Builder
+        public Studies {
+
+        }
+    }
+
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/Study.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/Study.java
@@ -5,6 +5,7 @@ import static lombok.AccessLevel.PROTECTED;
 import com.devcourse.checkmoi.domain.book.model.Book;
 import com.devcourse.checkmoi.global.model.BaseEntity;
 import java.time.LocalDate;
+import java.util.StringJoiner;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -14,6 +15,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Formula;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
@@ -28,6 +30,9 @@ public class Study extends BaseEntity {
     private String thumbnailUrl;
 
     private String description;
+
+    @Formula("(select count(1) from study_member sm where sm.study_id = id)")
+    private int currentParticipant;
 
     private Integer maxParticipant;
 
@@ -46,20 +51,21 @@ public class Study extends BaseEntity {
     private LocalDate studyEndDate;
 
     public Study(String name, String thumbnailUrl, String description, Integer maxParticipant,
-        Book book, LocalDate gatherStartDate, LocalDate gatherEndDate,
+        StudyStatus status, Book book, LocalDate gatherStartDate, LocalDate gatherEndDate,
         LocalDate studyStartDate, LocalDate studyEndDate) {
-        this(null, name, thumbnailUrl, description, maxParticipant, book, gatherStartDate,
+        this(null, name, thumbnailUrl, description, status, maxParticipant, book, gatherStartDate,
             gatherEndDate, studyStartDate, studyEndDate);
     }
 
     @Builder
-    public Study(Long id, String name, String thumbnailUrl, String description,
+    public Study(Long id, String name, String thumbnailUrl, String description, StudyStatus status,
         Integer maxParticipant, Book book, LocalDate gatherStartDate, LocalDate gatherEndDate,
         LocalDate studyStartDate, LocalDate studyEndDate) {
         this.id = id;
         this.name = name;
         this.thumbnailUrl = thumbnailUrl;
         this.description = description;
+        this.status = status;
         this.maxParticipant = maxParticipant;
         this.book = book;
         this.gatherStartDate = gatherStartDate;
@@ -76,6 +82,46 @@ public class Study extends BaseEntity {
         return book;
     }
 
+    public String getName() {
+        return name;
+    }
+
+    public String getThumbnailUrl() {
+        return thumbnailUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Integer getMaxParticipant() {
+        return maxParticipant;
+    }
+
+    public LocalDate getGatherStartDate() {
+        return gatherStartDate;
+    }
+
+    public LocalDate getGatherEndDate() {
+        return gatherEndDate;
+    }
+
+    public LocalDate getStudyStartDate() {
+        return studyStartDate;
+    }
+
+    public LocalDate getStudyEndDate() {
+        return studyEndDate;
+    }
+
+    public StudyStatus getStatus() {
+        return status;
+    }
+
+    public int getCurrentParticipant() {
+        return currentParticipant;
+    }
+
     public void editName(String name) {
         this.name = name;
     }
@@ -86,5 +132,23 @@ public class Study extends BaseEntity {
 
     public void editDescription(String description) {
         this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", Study.class.getSimpleName() + "[", "]")
+            .add("id=" + id)
+            .add("name='" + name + "'")
+            .add("thumbnailUrl='" + thumbnailUrl + "'")
+            .add("description='" + description + "'")
+            .add("currentParticipant=" + currentParticipant)
+            .add("maxParticipant=" + maxParticipant)
+            .add("status=" + status)
+            .add("book=" + book)
+            .add("gatherStartDate=" + gatherStartDate)
+            .add("gatherEndDate=" + gatherEndDate)
+            .add("studyStartDate=" + studyStartDate)
+            .add("studyEndDate=" + studyEndDate)
+            .toString();
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/Study.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/Study.java
@@ -5,7 +5,6 @@ import static lombok.AccessLevel.PROTECTED;
 import com.devcourse.checkmoi.domain.book.model.Book;
 import com.devcourse.checkmoi.global.model.BaseEntity;
 import java.time.LocalDate;
-import java.util.StringJoiner;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -134,21 +133,4 @@ public class Study extends BaseEntity {
         this.description = description;
     }
 
-    @Override
-    public String toString() {
-        return new StringJoiner(", ", Study.class.getSimpleName() + "[", "]")
-            .add("id=" + id)
-            .add("name='" + name + "'")
-            .add("thumbnailUrl='" + thumbnailUrl + "'")
-            .add("description='" + description + "'")
-            .add("currentParticipant=" + currentParticipant)
-            .add("maxParticipant=" + maxParticipant)
-            .add("status=" + status)
-            .add("book=" + book)
-            .add("gatherStartDate=" + gatherStartDate)
-            .add("gatherEndDate=" + gatherEndDate)
-            .add("studyStartDate=" + studyStartDate)
-            .add("studyEndDate=" + studyEndDate)
-            .toString();
-    }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyMember.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyMember.java
@@ -3,8 +3,6 @@ package com.devcourse.checkmoi.domain.study.model;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 import com.devcourse.checkmoi.domain.user.model.User;
-import java.util.StringJoiner;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -50,19 +48,5 @@ public class StudyMember {
 
     public User getUser() {
         return user;
-    }
-
-    public Study getStudy() {
-        return study;
-    }
-
-    @Override
-    public String toString() {
-        return new StringJoiner(", ", StudyMember.class.getSimpleName() + "[", "]")
-            .add("id=" + id)
-            .add("status=" + status)
-            .add("user=" + user)
-            .add("study=" + study)
-            .toString();
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyMember.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyMember.java
@@ -3,6 +3,8 @@ package com.devcourse.checkmoi.domain.study.model;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 import com.devcourse.checkmoi.domain.user.model.User;
+import java.util.StringJoiner;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -48,5 +50,19 @@ public class StudyMember {
 
     public User getUser() {
         return user;
+    }
+
+    public Study getStudy() {
+        return study;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", StudyMember.class.getSimpleName() + "[", "]")
+            .add("id=" + id)
+            .add("status=" + status)
+            .add("user=" + user)
+            .add("study=" + study)
+            .toString();
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepository.java
@@ -1,6 +1,13 @@
 package com.devcourse.checkmoi.domain.study.repository.study;
 
+import com.devcourse.checkmoi.domain.study.model.Study;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface CustomStudyRepository {
 
     Long findStudyOwner(Long studyId);
+
+    Page<Study> findRecruitingStudyByBookId(Long bookId, Pageable pageable);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepositoryImpl.java
@@ -2,9 +2,14 @@ package com.devcourse.checkmoi.domain.study.repository.study;
 
 import static com.devcourse.checkmoi.domain.study.model.QStudy.study;
 import static com.devcourse.checkmoi.domain.study.model.QStudyMember.studyMember;
+import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -25,6 +30,21 @@ public class CustomStudyRepositoryImpl implements
                 studyMember.status.eq(StudyMemberStatus.OWNED)
             )
             .fetchOne();
+    }
+
+    @Override
+    public Page<Study> findRecruitingStudyByBookId(Long bookId, Pageable pageable) {
+        return new PageImpl<>(
+            jpaQueryFactory.select(study)
+                .from(study)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .where(
+                    study.book.id.eq(bookId),
+                    study.status.eq(StudyStatus.RECRUTING)
+                )
+                .fetch()
+        );
     }
 
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/StudyMemberRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/StudyMemberRepository.java
@@ -1,7 +1,10 @@
 package com.devcourse.checkmoi.domain.study.repository.study;
 
+import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyMember;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
 

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandService.java
@@ -11,4 +11,5 @@ public interface StudyCommandService {
     Long editStudyInfo(Long studyId, Long userId, Edit request);
 
     void auditStudyParticipation(Long studyId, Long memberId, Long userId, Audit request);
+
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImpl.java
@@ -6,6 +6,7 @@ import com.devcourse.checkmoi.domain.study.converter.StudyConverter;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Audit;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Edit;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
 import com.devcourse.checkmoi.domain.study.exception.NotStudyOwnerException;
 import com.devcourse.checkmoi.domain.study.exception.StudyJoinRequestNotFoundException;
 import com.devcourse.checkmoi.domain.study.exception.StudyNotFoundException;

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyQueryService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyQueryService.java
@@ -1,0 +1,9 @@
+package com.devcourse.checkmoi.domain.study.service.study;
+
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
+import org.springframework.data.domain.Pageable;
+
+public interface StudyQueryService {
+
+    Studies getStudies(Long bookId, Pageable pageable);
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyQueryServiceImpl.java
@@ -1,0 +1,28 @@
+package com.devcourse.checkmoi.domain.study.service.study;
+
+import com.devcourse.checkmoi.domain.study.converter.StudyConverter;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
+import com.devcourse.checkmoi.domain.study.repository.study.StudyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StudyQueryServiceImpl implements
+    StudyQueryService {
+
+    private final StudyConverter studyConverter;
+
+    private final StudyRepository studyRepository;
+
+    @Override
+    public Studies getStudies(Long bookId, Pageable pageable) {
+        return new Studies(
+            studyRepository.findRecruitingStudyByBookId(bookId, pageable)
+                .map(studyConverter::studyToStudyInfo)
+        );
+    }
+}

--- a/src/main/java/com/devcourse/checkmoi/global/model/PageRequest.java
+++ b/src/main/java/com/devcourse/checkmoi/global/model/PageRequest.java
@@ -1,0 +1,31 @@
+package com.devcourse.checkmoi.global.model;
+
+import org.springframework.data.domain.Sort.Direction;
+
+public class PageRequest {
+
+    private int page = 1;
+
+    private int size = 10;
+
+    private Direction direction = Direction.DESC;
+
+    public void setPage(int page) {
+        this.page = page <= 0 ? 1 : page;
+    }
+
+    public void setSize(int size) {
+        int defaultSize = 10;
+        int maxSize = 50;
+        this.size = size > maxSize ? defaultSize : size;
+    }
+
+    public void setDirection(Direction direction) {
+        this.direction = direction;
+    }
+
+    public org.springframework.data.domain.PageRequest of() {
+        return org.springframework.data.domain.PageRequest.of(page - 1, size, direction,
+            "create_date");
+    }
+}

--- a/src/main/java/com/devcourse/checkmoi/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/devcourse/checkmoi/global/security/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.devcourse.checkmoi.global.security.handler.OAuthAuthenticationSuccess
 import com.devcourse.checkmoi.global.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -37,6 +38,7 @@ public class SecurityConfig {
             .authorizeHttpRequests()
             .antMatchers("/**/docs/**").permitAll()
             .antMatchers("/api/tokens").permitAll()
+            .antMatchers(HttpMethod.GET, "/api/studies").permitAll()
             .anyRequest().authenticated()
             .and()
 

--- a/src/test/java/com/devcourse/checkmoi/domain/book/stub/BookStub.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/book/stub/BookStub.java
@@ -1,0 +1,33 @@
+package com.devcourse.checkmoi.domain.book.stub;
+
+import com.devcourse.checkmoi.domain.book.model.Book;
+import com.devcourse.checkmoi.domain.book.model.PublishedDate;
+import java.time.LocalDate;
+import java.util.List;
+
+public class BookStub {
+    public static List<Book> StubBook() {
+        return List.of(
+            Book.builder()
+                .id(1L)
+                .title("자바")
+                .description("자바책")
+                .author("김자바")
+                .publisher("자바출판")
+                .isbn("0000000000000")
+                .thumbnail("https://example.com/java.png")
+                .publishedAt(new PublishedDate("20121111"))
+                .build(),
+            Book.builder()
+                .id(2L)
+                .title("자바스크립트")
+                .description("자바스크립트책")
+                .author("김자바스크립트")
+                .publisher("자바스크립트출판")
+                .isbn("0000000000001")
+                .thumbnail("https://example.com/java.png")
+                .publishedAt(new PublishedDate("20211201"))
+                .build()
+        );
+    }
+}

--- a/src/test/java/com/devcourse/checkmoi/domain/study/repository/study/StudyRepositoryTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/repository/study/StudyRepositoryTest.java
@@ -2,17 +2,30 @@ package com.devcourse.checkmoi.domain.study.repository.study;
 
 import static com.devcourse.checkmoi.domain.user.model.UserRole.GUEST;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import com.devcourse.checkmoi.domain.book.model.Book;
+import com.devcourse.checkmoi.domain.book.repository.BookRepository;
+import com.devcourse.checkmoi.domain.book.stub.BookStub;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyMember;
 import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import com.devcourse.checkmoi.domain.study.stub.StudyMemberStub;
+import com.devcourse.checkmoi.domain.study.stub.StudyStub;
 import com.devcourse.checkmoi.domain.user.model.User;
 import com.devcourse.checkmoi.domain.user.model.vo.Email;
 import com.devcourse.checkmoi.domain.user.repository.UserRepository;
+import com.devcourse.checkmoi.domain.user.stub.UserStub;
+import com.devcourse.checkmoi.global.model.PageRequest;
 import com.devcourse.checkmoi.template.RepositoryTest;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 class StudyRepositoryTest extends RepositoryTest {
 
@@ -24,6 +37,9 @@ class StudyRepositoryTest extends RepositoryTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
 
     @Nested
     @DisplayName("스터디 수정 #30")
@@ -57,6 +73,42 @@ class StudyRepositoryTest extends RepositoryTest {
 
             assertThat(got)
                 .isEqualTo(studyMember.getUser().getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("특정 책에 대한 스터디 목록 조회 #43")
+    class getStudies {
+
+        @PersistenceContext
+        private EntityManager entityManager;
+
+
+        @BeforeEach
+        void init() {
+            entityManager.createNativeQuery("ALTER TABLE book ALTER COLUMN `id` RESTART WITH 1")
+                .executeUpdate();
+            List<Book> books = BookStub.StubBook();
+            List<Study> studies = StudyStub.studiesStub();
+
+            userRepository.saveAll(UserStub.usersStub());
+            bookRepository.saveAll(books);
+            studyRepository.saveAll(studies);
+            studyMemberRepository.saveAll(StudyMemberStub.studyMembers());
+        }
+
+        @Test
+        @DisplayName("책 아이디를 기준으로 모집중인 스터디 정보를 조회한다.")
+        void findRecruitingStudyByBookId() {
+            PageRequest pageRequest = new PageRequest();
+            Pageable pageable = pageRequest.of();
+            Page<Study> got = studyRepository.findRecruitingStudyByBookId(1L, pageable);
+            List<String> want = StudyStub.javaRecrutingStudyNameStub();
+
+            assertThat(got).hasSize(want.size());
+            for (int i = 0; i < got.getSize(); i++) {
+                assertThat(got.getContent().get(i).getName()).isEqualTo(want.get(i));
+            }
         }
     }
 }

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/study/StudyQueryServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/study/StudyQueryServiceImplTest.java
@@ -1,0 +1,80 @@
+package com.devcourse.checkmoi.domain.study.service.study;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import com.devcourse.checkmoi.domain.study.converter.StudyConverter;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
+import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.repository.study.StudyRepository;
+import com.devcourse.checkmoi.domain.study.stub.StudyStub;
+import com.devcourse.checkmoi.global.model.PageRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class StudyQueryServiceImplTest {
+
+    @InjectMocks
+    StudyQueryServiceImpl studyQueryService;
+
+    @Mock
+    StudyConverter studyConverter;
+
+    @Mock
+    StudyRepository studyRepository;
+
+    @Nested
+    @DisplayName("특정 책에 대한 스터디 목록 조회 #43")
+    class GetStudies {
+
+        @Test
+        @DisplayName("현재 모집중인 특정 책에 대한 스터디 목록 조회")
+        void getStudies() {
+            Long bookId = 1L;
+            PageRequest pageRequest = new PageRequest();
+            Pageable pageable = pageRequest.of();
+            Page<Study> studies = new PageImpl<>(
+                StudyStub.javaRecrutingStudyStub()
+            );
+            Page<StudyInfo> studyInfos = studies.map(
+                study -> StudyInfo.builder()
+                    .id(study.getId())
+                    .name(study.getName())
+                    .thumbnailUrl(study.getThumbnailUrl())
+                    .description(study.getDescription())
+                    .currentParticipant(study.getCurrentParticipant())
+                    .maxParticipant(study.getMaxParticipant())
+                    .gatherStartDate(study.getGatherStartDate())
+                    .gatherEndDate(study.getGatherEndDate())
+                    .studyStartDate(study.getStudyStartDate())
+                    .studyEndDate(study.getStudyEndDate())
+                    .build()
+            );
+            Studies want = Studies.builder()
+                .studies(studyInfos)
+                .build();
+            given(studyRepository.findRecruitingStudyByBookId(anyLong(), any(Pageable.class)))
+                .willReturn(studies);
+            given(studyConverter.studyToStudyInfo(studies.getContent().get(0))).willReturn(
+                studyInfos.getContent().get(0));
+            given(studyConverter.studyToStudyInfo(studies.getContent().get(1))).willReturn(
+                studyInfos.getContent().get(1));
+
+            Studies got = studyQueryService.getStudies(bookId, pageable);
+
+            assertThat(got).usingRecursiveComparison().isEqualTo(want);
+        }
+    }
+}
+

--- a/src/test/java/com/devcourse/checkmoi/domain/study/stub/StudyMemberStub.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/stub/StudyMemberStub.java
@@ -1,0 +1,50 @@
+package com.devcourse.checkmoi.domain.study.stub;
+
+import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
+import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import com.devcourse.checkmoi.domain.user.model.User;
+import com.devcourse.checkmoi.domain.user.stub.UserStub;
+import java.util.List;
+
+public class StudyMemberStub {
+
+    private static final List<User> users = UserStub.usersStub();
+    private static final List<Study> studies = StudyStub.studiesStub();
+
+    public static List<StudyMember> studyMembers() {
+        return List.of(
+            StudyMember.builder()
+                .id(1L)
+                .status(StudyMemberStatus.ACCEPTED)
+                .user(users.get(0))
+                .study(studies.get(0))
+                .build(),
+            StudyMember.builder()
+                .id(2L)
+                .status(StudyMemberStatus.ACCEPTED)
+                .user(users.get(1))
+                .study(studies.get(0))
+                .build(),
+            StudyMember.builder()
+                .id(3L)
+                .status(StudyMemberStatus.ACCEPTED)
+                .user(users.get(2))
+                .study(studies.get(0))
+                .build(),
+            StudyMember.builder()
+                .id(4L)
+                .status(StudyMemberStatus.ACCEPTED)
+                .user(users.get(3))
+                .study(studies.get(2))
+                .build(),
+            StudyMember.builder()
+                .id(5L)
+                .status(StudyMemberStatus.ACCEPTED)
+                .user(users.get(4))
+                .study(studies.get(2))
+                .build()
+        );
+    }
+
+}

--- a/src/test/java/com/devcourse/checkmoi/domain/study/stub/StudyStub.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/stub/StudyStub.java
@@ -1,0 +1,120 @@
+package com.devcourse.checkmoi.domain.study.stub;
+
+import com.devcourse.checkmoi.domain.book.model.Book;
+import com.devcourse.checkmoi.domain.book.stub.BookStub;
+import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.model.StudyStatus;
+import java.time.LocalDate;
+import java.util.List;
+
+public class StudyStub {
+    private static final List<Book> book = BookStub.StubBook();
+
+    public static List<String> javaRecrutingStudyNameStub() {
+        return List.of(
+            "자바 스터디 1",
+            "자바 스터디 3"
+        );
+    }
+
+    public static List<Study> javaRecrutingStudyStub() {
+        return List.of(
+            Study.builder()
+                .id(1L)
+                .name("자바 스터디 1")
+                .thumbnailUrl("https://example.com/java.png")
+                .description("자바 스터디 1번입니다.")
+                .maxParticipant(3)
+                .status(StudyStatus.RECRUTING)
+                .book(book.get(0))
+                .gatherStartDate(LocalDate.now())
+                .gatherEndDate(LocalDate.now())
+                .studyStartDate(LocalDate.now())
+                .studyEndDate(LocalDate.now())
+                .build(),
+            Study.builder()
+                .id(3L)
+                .name("자바 스터디 3")
+                .thumbnailUrl("https://example.com/java3.png")
+                .description("자바 스터디 3번입니다.")
+                .maxParticipant(3)
+                .status(StudyStatus.RECRUTING)
+                .book(book.get(0))
+                .gatherStartDate(LocalDate.now())
+                .gatherEndDate(LocalDate.now())
+                .studyStartDate(LocalDate.now())
+                .studyEndDate(LocalDate.now())
+                .build()
+        );
+    }
+    public static List<Study> studiesStub() {
+        return List.of(
+            Study.builder()
+                .id(1L)
+                .name("자바 스터디 1")
+                .thumbnailUrl("https://example.com/java.png")
+                .description("자바 스터디 1번입니다.")
+                .maxParticipant(3)
+                .status(StudyStatus.RECRUTING)
+                .book(book.get(0))
+                .gatherStartDate(LocalDate.now())
+                .gatherEndDate(LocalDate.now())
+                .studyStartDate(LocalDate.now())
+                .studyEndDate(LocalDate.now())
+                .build(),
+            Study.builder()
+                .id(2L)
+                .name("자바 스터디 2")
+                .thumbnailUrl("https://example.com/java2.png")
+                .description("자바 스터디 2번입니다.")
+                .maxParticipant(7)
+                .status(StudyStatus.FINISHED)
+                .book(book.get(0))
+                .gatherStartDate(LocalDate.now())
+                .gatherEndDate(LocalDate.now())
+                .studyStartDate(LocalDate.now())
+                .studyEndDate(LocalDate.now())
+                .build(),
+            Study.builder()
+                .id(3L)
+                .name("자바 스터디 3")
+                .thumbnailUrl("https://example.com/java3.png")
+                .description("자바 스터디 3번입니다.")
+                .maxParticipant(3)
+                .status(StudyStatus.RECRUTING)
+                .book(book.get(0))
+                .gatherStartDate(LocalDate.now())
+                .gatherEndDate(LocalDate.now())
+                .studyStartDate(LocalDate.now())
+                .studyEndDate(LocalDate.now())
+                .build(),
+            Study.builder()
+                .id(4L)
+                .name("자바스크립트 스터디 1")
+                .thumbnailUrl("https://example.com/java.png")
+                .description("자바스크립트 스터디 1번입니다.")
+                .maxParticipant(3)
+                .status(StudyStatus.RECRUTING)
+                .book(book.get(1))
+                .gatherStartDate(LocalDate.now())
+                .gatherEndDate(LocalDate.now())
+                .studyStartDate(LocalDate.now())
+                .studyEndDate(LocalDate.now())
+                .build(),
+            Study.builder()
+                .id(5L)
+                .name("자바스크립트 스터디 2")
+                .thumbnailUrl("https://example.com/java.png")
+                .description("자바스크립트 스터디 2번입니다.")
+                .maxParticipant(11)
+                .status(StudyStatus.IN_PROGRESS)
+                .book(book.get(1))
+                .gatherStartDate(LocalDate.now())
+                .gatherEndDate(LocalDate.now())
+                .studyStartDate(LocalDate.now())
+                .studyEndDate(LocalDate.now())
+                .build()
+        );
+    }
+
+}

--- a/src/test/java/com/devcourse/checkmoi/domain/user/api/UserIntegrationTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/user/api/UserIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import com.devcourse.checkmoi.domain.token.dto.TokenResponse.TokenWithUserInfo;
 import com.devcourse.checkmoi.template.IntegrationTest;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/devcourse/checkmoi/domain/user/stub/UserStub.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/user/stub/UserStub.java
@@ -1,0 +1,59 @@
+package com.devcourse.checkmoi.domain.user.stub;
+
+import com.devcourse.checkmoi.domain.user.model.User;
+import com.devcourse.checkmoi.domain.user.model.UserRole;
+import com.devcourse.checkmoi.domain.user.model.vo.Email;
+import java.util.List;
+
+public class UserStub {
+
+    public static List<User> usersStub() {
+        return List.of(
+            User.builder()
+                .id(1L)
+                .oauthId("ASDASDQWDAASDZFWEF1")
+                .provider("KAKAO")
+                .name("user1")
+                .email(new Email("user1@test.com"))
+                .profileImgUrl("https://example.com/java.png")
+                .userRole(UserRole.GUEST)
+                .build(),
+            User.builder()
+                .id(2L)
+                .oauthId("ASDASDQWDAASDZFWEF2")
+                .provider("KAKAO")
+                .name("user2")
+                .email(new Email("user2@test.com"))
+                .profileImgUrl("https://example.com/java2.png")
+                .userRole(UserRole.GUEST)
+                .build(),
+            User.builder()
+                .id(3L)
+                .oauthId("ASDASDQWDAASDZFWEF3")
+                .provider("KAKAO")
+                .name("user3")
+                .email(new Email("user3@test.com"))
+                .profileImgUrl("https://example.com/java.png")
+                .userRole(UserRole.HOST)
+                .build(),
+            User.builder()
+                .id(4L)
+                .oauthId("ASDASDQWDAASDZFWEF4")
+                .provider("KAKAO")
+                .name("user4")
+                .email(new Email("user4@test.com"))
+                .profileImgUrl("https://example.com/java.png")
+                .userRole(UserRole.GUEST)
+                .build(),
+            User.builder()
+                .id(5L)
+                .oauthId("ASDASDQWDAASDZFWEF5")
+                .provider("KAKAO")
+                .name("user5")
+                .email(new Email("user5@test.com"))
+                .profileImgUrl("https://example.com/java5.png")
+                .userRole(UserRole.HOST)
+                .build()
+        );
+    }
+}

--- a/src/test/java/com/devcourse/checkmoi/template/RepositoryTest.java
+++ b/src/test/java/com/devcourse/checkmoi/template/RepositoryTest.java
@@ -3,6 +3,7 @@ package com.devcourse.checkmoi.template;
 import com.devcourse.checkmoi.config.QueryConfig;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest


### PR DESCRIPTION
## 작업사항

- 특정 책 ID를 받으면 해당 아이디에 대한 스터디 목록을 조회하는 기능 추가
- 현재 모집중인 스터디만 나오도록 구현
- 로그인을 하지 않아도 목록을 볼 수 있도록 시큐리티 체인에서 예외 설정 추가
- 스터디 목록에 대해서 커스텀 페이지네이션 처리
- API 문서화와 테스트 코드 작성 추가
- 페이지 처리를 포함하는 queryDSL 작성

<img width="1475" alt="image" src="https://user-images.githubusercontent.com/41960243/182046773-4cc0aaf9-73db-4742-b421-9794f10959f4.png">
<img width="1420" alt="image" src="https://user-images.githubusercontent.com/41960243/182046784-c20c0426-5b0b-4757-b011-3bc53ce9ed1a.png">


## 중점적으로 봐야할 부분
- 현재 카운트 쿼리를 집계하는 필드를 Study 엔티티에 추가했으나 쿼리는 실행되나 값이 불러와지지 않는 이상현상이 발생한 상태입니다.
일단 해당 부분은 이슈로 남겨두고 나머지 부분 먼저 올리겠습니다.
- resolves #43 
