### PR TITLE
✨  feat : 스터디 참가 신청 기능 구현

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
@@ -52,7 +52,7 @@ public class StudyApi {
             new SuccessResponse<>(studyCommandService.editStudyInfo(studyId, user.id(), request)));
     }
 
-    @PutMapping("/{studyId}/member/{memberId}")
+    @PutMapping("/{studyId}/members/{memberId}")
     public ResponseEntity<Void> auditStudyParticipation(
         @PathVariable Long studyId,
         @PathVariable Long memberId,
@@ -75,7 +75,7 @@ public class StudyApi {
         return ResponseEntity.ok(new SuccessResponse<>(response));
     }
 
-    @PutMapping("/{studyId}/study-member")
+    @PutMapping("/{studyId}/members")
     public ResponseEntity<SuccessResponse<Long>> requestStudyJoin(@PathVariable Long studyId,
         @AuthenticationPrincipal JwtAuthentication user) {
         Long studyMemberId = studyCommandService.requestStudyJoin(studyId, user.id());

--- a/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
@@ -75,4 +75,11 @@ public class StudyApi {
         return ResponseEntity.ok(new SuccessResponse<>(response));
     }
 
+    @PutMapping("/{studyId}/study-member")
+    public ResponseEntity<SuccessResponse<Long>> requestStudyJoin(@PathVariable Long studyId,
+        @AuthenticationPrincipal JwtAuthentication user) {
+        Long studyMemberId = studyCommandService.requestStudyJoin(studyId, user.id());
+        return ResponseEntity.ok()
+            .body(new SuccessResponse<>(studyMemberId));
+    }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/exception/DuplicateStudyJoinRequestException.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/exception/DuplicateStudyJoinRequestException.java
@@ -1,0 +1,12 @@
+package com.devcourse.checkmoi.domain.study.exception;
+
+import com.devcourse.checkmoi.global.exception.DuplicateException;
+import com.devcourse.checkmoi.global.exception.ErrorMessage;
+
+public class DuplicateStudyJoinRequestException extends DuplicateException {
+
+    public DuplicateStudyJoinRequestException(
+        ErrorMessage errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyMember.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyMember.java
@@ -3,6 +3,7 @@ package com.devcourse.checkmoi.domain.study.model;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 import com.devcourse.checkmoi.domain.user.model.User;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -44,6 +45,10 @@ public class StudyMember {
 
     public StudyMemberStatus getStatus() {
         return status;
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public User getUser() {

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/StudyMemberRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/StudyMemberRepository.java
@@ -1,11 +1,11 @@
 package com.devcourse.checkmoi.domain.study.repository.study;
 
-import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyMember;
-import java.util.List;
+import com.devcourse.checkmoi.domain.user.model.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
 
+    Optional<StudyMember> findByUser(User user);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandService.java
@@ -12,4 +12,5 @@ public interface StudyCommandService {
 
     void auditStudyParticipation(Long studyId, Long memberId, Long userId, Audit request);
 
+    Long requestStudyJoin(Long studyId, Long userId);
 }

--- a/src/main/java/com/devcourse/checkmoi/global/exception/DuplicateException.java
+++ b/src/main/java/com/devcourse/checkmoi/global/exception/DuplicateException.java
@@ -1,0 +1,13 @@
+package com.devcourse.checkmoi.global.exception;
+
+public class DuplicateException extends BusinessException {
+
+    public DuplicateException(String message,
+        ErrorMessage errorMessage) {
+        super(message, errorMessage);
+    }
+
+    public DuplicateException(ErrorMessage errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/devcourse/checkmoi/global/exception/ErrorMessage.java
+++ b/src/main/java/com/devcourse/checkmoi/global/exception/ErrorMessage.java
@@ -19,7 +19,10 @@ public enum ErrorMessage {
     // not found error
     STUDY_NOT_FOUND("해당하는 스터디를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     BOOK_NOT_FOUND("해당하는 책을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
-    STUDY_JOIN_REQUEST_NOT_FOUND("해당하는 스터디 가입 요청을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    STUDY_JOIN_REQUEST_NOT_FOUND("해당하는 스터디 가입 요청을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    // duplicate error
+    STUDY_JOIN_REQUEST_DUPLICATE("이미 스터디 가입 요청을 완료했습니다.", HttpStatus.CONFLICT);
 
     private final String message;
 

--- a/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
@@ -193,7 +193,7 @@ class StudyApiTest extends IntegrationTest {
                 .build();
 
             ResultActions result = mockMvc.perform(
-                put("/api/studies/{studyId}/member/{memberId}", studyId, memberId)
+                put("/api/studies/{studyId}/members/{memberId}", studyId, memberId)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + givenUser.accessToken())
                     .contentType(MediaType.APPLICATION_JSON).characterEncoding("utf-8")
                     .content(toJson(request)));
@@ -331,7 +331,7 @@ class StudyApiTest extends IntegrationTest {
             given(studyCommandService.requestStudyJoin(studyId, givenUser.userInfo().id()))
                 .willReturn(studyMemberId);
             ResultActions result = mockMvc.perform(
-                put("/api/studies/{studyId}/study-member", studyId)
+                put("/api/studies/{studyId}/members", studyId)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + givenUser.accessToken()));
 
             result.andExpect(status().isOk())

--- a/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
@@ -318,4 +318,44 @@ class StudyApiTest extends IntegrationTest {
             );
         }
     }
+
+    @Nested
+    @DisplayName("스터디 가입 신청 #52")
+    class RequestStudyJoinTest {
+
+        @Test
+        void requestStudyJoin() throws Exception {
+            TokenWithUserInfo givenUser = getTokenWithUserInfo();
+            Long studyId = 1L;
+            Long studyMemberId = 1L;
+            given(studyCommandService.requestStudyJoin(studyId, givenUser.userInfo().id()))
+                .willReturn(studyMemberId);
+            ResultActions result = mockMvc.perform(
+                put("/api/studies/{studyId}/study-member", studyId)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + givenUser.accessToken()));
+
+            result.andExpect(status().isOk())
+                .andDo(documentation())
+                .andExpect(jsonPath("$.data").value(studyMemberId));
+
+        }
+
+        private RestDocumentationResultHandler documentation() {
+            return MockMvcRestDocumentationWrapper.document("study-join-request",
+                ResourceSnippetParameters.builder()
+                    .tag("Study API")
+                    .summary("스터디 가입 신청")
+                    .description("스터디 가입 신청에 사용되는 API입니다.")
+                    .responseSchema(Schema.schema("스터디 가입 요청 응답")),
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                tokenRequestHeader(),
+                pathParameters(
+                    parameterWithName("studyId").description("스터디 Id")
+                ),
+                responseFields(
+                    fieldWithPath("data").description("스터디 멤버 Id")
+                ));
+        }
+    }
 }

--- a/src/test/java/com/devcourse/checkmoi/domain/study/stub/StudyMemberStub.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/stub/StudyMemberStub.java
@@ -55,4 +55,22 @@ public class StudyMemberStub {
             .study(studies.get(0))
             .build();
     }
+
+    public static StudyMember deniedStudyMember() {
+        return StudyMember.builder()
+            .id(1L)
+            .status(StudyMemberStatus.DENIED)
+            .user(users.get(0))
+            .study(studies.get(0))
+            .build();
+    }
+
+    public static StudyMember pendingStudyMember() {
+        return StudyMember.builder()
+            .id(1L)
+            .status(StudyMemberStatus.DENIED)
+            .user(users.get(0))
+            .study(studies.get(0))
+            .build();
+    }
 }

--- a/src/test/java/com/devcourse/checkmoi/domain/study/stub/StudyStub.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/stub/StudyStub.java
@@ -117,4 +117,19 @@ public class StudyStub {
         );
     }
 
+    public static Study study() {
+        return Study.builder()
+            .id(1L)
+            .name("자바 스터디 1")
+            .thumbnailUrl("https://example.com/java.png")
+            .description("자바 스터디 1번입니다.")
+            .maxParticipant(3)
+            .status(StudyStatus.RECRUTING)
+            .book(book.get(0))
+            .gatherStartDate(LocalDate.now())
+            .gatherEndDate(LocalDate.now())
+            .studyStartDate(LocalDate.now())
+            .studyEndDate(LocalDate.now())
+            .build();
+    }
 }


### PR DESCRIPTION
## 작업사항

- 사용자가 스터디 참가 신청을 할 수 있는 기능을 구현
- 스터디 참가 신청을 이전에 하지 않았다면 해당 칼럼을 생성 아니라면 상태 확인후 DENIED인 경우에만 PENDING으로 변경
- 상태가 DENIED가 아니면 Duplicate Exception을 발생 시킴
- 스터디 참가 신청에 대한 테스트 코드 작성 및 API 문서화 완료

<img width="1412" alt="image" src="https://user-images.githubusercontent.com/41960243/182067944-ed9b7813-b016-4a69-bd6e-9459d27f1d86.png">

- resolves #52 
