### PR TITLE
🐛 fix : OAuth2 cors 허용 메서드 확대

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/global/config/WebConfig.java
+++ b/src/main/java/com/devcourse/checkmoi/global/config/WebConfig.java
@@ -1,7 +1,6 @@
 package com.devcourse.checkmoi.global.config;
 
-import static org.springframework.http.HttpHeaders.*;
-
+import static org.springframework.http.HttpHeaders.LOCATION;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -9,7 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private static final String ALLOWED_METHOD_NAMES = "GET,POST,PUT,DELETE,HEAD";
+    private static final String ALLOWED_METHOD_NAMES = "GET,POST,PUT,DELETE,HEAD,OPTIONS";
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -17,5 +16,5 @@ public class WebConfig implements WebMvcConfigurer {
             .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
             .exposedHeaders(LOCATION);
     }
-    
+
 }


### PR DESCRIPTION
## 작업사항
### before
allowedMethods "GET,POST,PUT,DELETE,HEAD";
### after
allowedMethods "GET,POST,PUT,DELETE,HEAD,OPTIONS"

### 상황
> POST 요청으로 보내더라도 OPTIONS 요청으로 갔으며 preflight 요청이 통과되지 않았다는 메시지가 있는 것을 알 수 있다. 
CORS로 요청을 할 때 보통 사전에 preflight 요청을 통해 서버 측에서 응답 헤더에 CORS와 관련에 헤더를 담아서 보내줘야 한다.

[참고자료](https://sun-22.tistory.com/60)

## 중점적으로 봐야할 부분

- resolves #68 
