### PR TITLE
♻️ refactor : 회원 정보 조회 API 변경

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/user/api/UserApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/user/api/UserApi.java
@@ -28,9 +28,8 @@ public class UserApi {
 
     private final UserCommandService userCommandService;
 
-    @GetMapping("/users/{userId}")
+    @GetMapping("/me")
     ResponseEntity<SuccessResponse<UserInfoWithStudy>> userPage(
-        @PathVariable Long userId,
         @AuthenticationPrincipal JwtAuthentication user
     ) {
         return ResponseEntity.ok()

--- a/src/main/java/com/devcourse/checkmoi/global/security/handler/OAuthAuthenticationSuccessHandler.java
+++ b/src/main/java/com/devcourse/checkmoi/global/security/handler/OAuthAuthenticationSuccessHandler.java
@@ -2,7 +2,6 @@ package com.devcourse.checkmoi.global.security.handler;
 
 import com.devcourse.checkmoi.global.security.oauth.OAuthProvider;
 import com.devcourse.checkmoi.global.security.oauth.OAuthService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -20,8 +19,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class OAuthAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
     private final OAuthService oauthService;
-
-    private final ObjectMapper objectMapper;
 
     @Override
     public void onAuthenticationSuccess(

--- a/src/test/java/com/devcourse/checkmoi/domain/user/api/UserIntegrationTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/user/api/UserIntegrationTest.java
@@ -54,7 +54,7 @@ class UserIntegrationTest extends IntegrationTest {
         @DisplayName("S 회원 상세 페이지 조회")
         void userPage() throws Exception {
             TokenWithUserInfo givenUser = getTokenWithUserInfo();
-            mockMvc.perform(get("/api/users/{userId}", givenUser.userInfo().id())
+            mockMvc.perform(get("/api/me")
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + givenUser.accessToken()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id")
@@ -76,9 +76,6 @@ class UserIntegrationTest extends IntegrationTest {
                     .description("회원 정보를 요청하는 API 입니다."),
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
-                pathParameters(
-                    parameterWithName("userId").description("회원 아이디")
-                ),
                 tokenRequestHeader()
             );
         }


### PR DESCRIPTION
## 작업사항
`/api/users/{userId}` → `/api/me` 로 변경

## 중점적으로 봐야할 부분

- resolves #76 
