### PR TITLE
✨ feat : 스터디 상세 조회

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
@@ -5,6 +5,7 @@ import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Audit;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Edit;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import com.devcourse.checkmoi.domain.study.service.study.StudyCommandService;
 import com.devcourse.checkmoi.domain.study.service.study.StudyQueryService;
 import com.devcourse.checkmoi.global.model.PageRequest;
@@ -33,6 +34,15 @@ public class StudyApi {
     private final StudyCommandService studyCommandService;
 
     private final StudyQueryService studyQueryService;
+
+    @GetMapping("/{studyId}")
+    public ResponseEntity<SuccessResponse<StudyDetailWithMembers>> getDetailInfo(
+        @PathVariable Long studyId
+    ) {
+        return ResponseEntity.ok()
+            .body(new SuccessResponse<>(studyQueryService.getStudyInfoWithMembers(studyId)));
+    }
+
 
     @PostMapping
     public ResponseEntity<SuccessResponse<Long>> createStudy(

--- a/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyResponse.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyResponse.java
@@ -1,13 +1,18 @@
 package com.devcourse.checkmoi.domain.study.dto;
 
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyBookInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
+import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfo;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 import org.springframework.data.domain.Page;
 
-public sealed interface StudyResponse permits StudyInfo, Studies {
+public sealed interface StudyResponse permits
+    StudyInfo, StudyDetailWithMembers, Studies, StudyDetailInfo, StudyBookInfo {
 
     record StudyInfo(
         Long id,
@@ -28,6 +33,55 @@ public sealed interface StudyResponse permits StudyInfo, Studies {
         }
     }
 
+    record StudyDetailInfo(
+        Long id,
+        String name,
+        String thumbnailUrl,
+        String description,
+
+        Integer currentParticipant,
+        Integer maxParticipant,
+
+        LocalDate gatherStartDate,
+        LocalDate gatherEndDate,
+
+        LocalDate studyStartDate,
+        LocalDate studyEndDate,
+
+        StudyBookInfo book
+    ) implements StudyResponse {
+
+        @Builder
+        public StudyDetailInfo {
+
+        }
+    }
+
+    record StudyBookInfo(
+        Long bookId,
+        String title,
+        String author,
+        String publisher,
+        String thumbnail
+    ) implements StudyResponse {
+
+        @Builder
+        public StudyBookInfo {
+
+        }
+    }
+
+    record StudyDetailWithMembers(
+        StudyDetailInfo study,
+        List<UserInfo> members
+    ) implements StudyResponse {
+
+        @Builder
+        public StudyDetailWithMembers {
+
+        }
+    }
+
     record Studies(
         Page<StudyInfo> studies
     ) implements StudyResponse {
@@ -37,5 +91,6 @@ public sealed interface StudyResponse permits StudyInfo, Studies {
 
         }
     }
+
 
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyResponse.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyResponse.java
@@ -6,6 +6,7 @@ import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailInfo;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
 import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfo;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
@@ -21,9 +22,13 @@ public sealed interface StudyResponse permits
         String description,
         int currentParticipant,
         Integer maxParticipant,
+        @JsonFormat(pattern = "yyyy/MM/dd")
         LocalDate gatherStartDate,
+        @JsonFormat(pattern = "yyyy/MM/dd")
         LocalDate gatherEndDate,
+        @JsonFormat(pattern = "yyyy/MM/dd")
         LocalDate studyStartDate,
+        @JsonFormat(pattern = "yyyy/MM/dd")
         LocalDate studyEndDate
     ) implements StudyResponse {
 
@@ -41,11 +46,13 @@ public sealed interface StudyResponse permits
 
         Integer currentParticipant,
         Integer maxParticipant,
-
+        @JsonFormat(pattern = "yyyy/MM/dd")
         LocalDate gatherStartDate,
+        @JsonFormat(pattern = "yyyy/MM/dd")
         LocalDate gatherEndDate,
-
+        @JsonFormat(pattern = "yyyy/MM/dd")
         LocalDate studyStartDate,
+        @JsonFormat(pattern = "yyyy/MM/dd")
         LocalDate studyEndDate,
 
         StudyBookInfo book

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyMember.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyMember.java
@@ -3,7 +3,7 @@ package com.devcourse.checkmoi.domain.study.model;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 import com.devcourse.checkmoi.domain.user.model.User;
-import javax.persistence.Column;
+import com.devcourse.checkmoi.global.model.BaseEntity;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
-public class StudyMember {
+public class StudyMember extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -53,5 +53,9 @@ public class StudyMember {
 
     public User getUser() {
         return user;
+    }
+
+    public Study getStudy() {
+        return study;
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepository.java
@@ -1,7 +1,7 @@
 package com.devcourse.checkmoi.domain.study.repository.study;
 
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import com.devcourse.checkmoi.domain.study.model.Study;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,4 +10,6 @@ public interface CustomStudyRepository {
     Long findStudyOwner(Long studyId);
 
     Page<Study> findRecruitingStudyByBookId(Long bookId, Pageable pageable);
+
+    StudyDetailWithMembers getStudyInfoWithMembers(Long studyId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepositoryImpl.java
@@ -2,10 +2,16 @@ package com.devcourse.checkmoi.domain.study.repository.study;
 
 import static com.devcourse.checkmoi.domain.study.model.QStudy.study;
 import static com.devcourse.checkmoi.domain.study.model.QStudyMember.studyMember;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyBookInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
 import com.devcourse.checkmoi.domain.study.model.StudyStatus;
+import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfo;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -14,8 +20,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class CustomStudyRepositoryImpl implements
-    CustomStudyRepository {
+public class CustomStudyRepositoryImpl implements CustomStudyRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
@@ -47,4 +52,51 @@ public class CustomStudyRepositoryImpl implements
         );
     }
 
+    @Override
+    public StudyDetailWithMembers getStudyInfoWithMembers(Long studyId) {
+        StudyDetailInfo studyInfo = getStudyInfo(studyId);
+        List<UserInfo> memberInfo = getStudyMembers(studyId);
+
+        return StudyDetailWithMembers.builder()
+            .study(studyInfo)
+            .members(memberInfo)
+            .build();
+    }
+
+    private StudyDetailInfo getStudyInfo(Long studyId) {
+        return jpaQueryFactory.select(
+                Projections.constructor(
+                    StudyDetailInfo.class,
+                    study.id, study.name, study.thumbnailUrl, study.description,
+                    study.currentParticipant, study.maxParticipant,
+                    study.gatherStartDate, study.gatherEndDate,
+                    study.studyStartDate, study.studyEndDate,
+                    Projections.constructor(
+                        StudyBookInfo.class,
+                        study.book.id, study.book.title,
+                        study.book.author, study.book.publisher, study.book.thumbnail
+                    )
+                ))
+            .from(study)
+            .innerJoin(study.book)
+            .where(study.id.eq(studyId))
+            .fetchOne();
+    }
+
+    private List<UserInfo> getStudyMembers(Long studyId) {
+        return jpaQueryFactory.select(
+                Projections.constructor(
+                    UserInfo.class,
+                    studyMember.user.id,
+                    studyMember.user.name,
+                    studyMember.user.email.value.as("email"),
+                    studyMember.user.profileImgUrl
+                )
+            )
+            .from(studyMember)
+            .innerJoin(studyMember.user)
+            .where(studyMember.study.id.eq(studyId))
+            .orderBy(studyMember.createdAt.asc())
+            .fetch();
+    }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyQueryService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyQueryService.java
@@ -1,9 +1,12 @@
 package com.devcourse.checkmoi.domain.study.service.study;
 
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import org.springframework.data.domain.Pageable;
 
 public interface StudyQueryService {
 
     Studies getStudies(Long bookId, Pageable pageable);
+
+    StudyDetailWithMembers getStudyInfoWithMembers(Long studyId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/study/StudyQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.devcourse.checkmoi.domain.study.service.study;
 
 import com.devcourse.checkmoi.domain.study.converter.StudyConverter;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import com.devcourse.checkmoi.domain.study.repository.study.StudyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -11,8 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class StudyQueryServiceImpl implements
-    StudyQueryService {
+public class StudyQueryServiceImpl implements StudyQueryService {
 
     private final StudyConverter studyConverter;
 
@@ -24,5 +24,10 @@ public class StudyQueryServiceImpl implements
             studyRepository.findRecruitingStudyByBookId(bookId, pageable)
                 .map(studyConverter::studyToStudyInfo)
         );
+    }
+
+    @Override
+    public StudyDetailWithMembers getStudyInfoWithMembers(Long studyId) {
+        return studyRepository.getStudyInfoWithMembers(studyId);
     }
 }

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -8,7 +8,7 @@ spring:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
             scope: profile_nickname, profile_image, account_email, birthday
-            redirect-uri: http://localhost:3000
+            redirect-uri: ${SERVER_NAME}/login/oauth2/code/kakao
             client-authentication-method: POST
             authorization-grant-type: authorization_code
         provider:

--- a/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
@@ -260,7 +260,7 @@ class StudyApiTest extends IntegrationTest {
                 .willReturn(response);
 
             ResultActions result = mockMvc.perform(
-                RestDocumentationRequestBuilders.get("/api/studies")
+                get("/api/studies")
                     .param("bookId", String.valueOf(bookId))
                     .param("size", "2")
                     .param("page", "1")
@@ -276,7 +276,7 @@ class StudyApiTest extends IntegrationTest {
             return MockMvcRestDocumentationWrapper.document("study-get-by-book",
                 ResourceSnippetParameters.builder()
                     .tag("Study API")
-                    .summary("선택한 책의 모집중인 스터디 목록 확인 (개발중)")
+                    .summary("선택한 책의 모집중인 스터디 목록 확인")
                     .description("선택한 책의 모집중인 스터디 목록 확인하는 API 입니다.")
                     .responseSchema(Schema.schema("선택한 책의 모집중인 스터디 목록 응답")),
                 preprocessRequest(prettyPrint()),
@@ -404,7 +404,7 @@ class StudyApiTest extends IntegrationTest {
         }
 
         private RestDocumentationResultHandler documentation() {
-            return MockMvcRestDocumentationWrapper.document("study-join-request",
+            return MockMvcRestDocumentationWrapper.document("study-detail-info",
                 ResourceSnippetParameters.builder()
                     .tag("Study API")
                     .summary("스터디 상세 조회 API")

--- a/src/test/java/com/devcourse/checkmoi/util/EntityGeneratorUtil.java
+++ b/src/test/java/com/devcourse/checkmoi/util/EntityGeneratorUtil.java
@@ -1,0 +1,66 @@
+package com.devcourse.checkmoi.util;
+
+import com.devcourse.checkmoi.domain.book.model.Book;
+import com.devcourse.checkmoi.domain.book.model.PublishedDate;
+import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
+import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import com.devcourse.checkmoi.domain.study.model.StudyStatus;
+import com.devcourse.checkmoi.domain.user.model.User;
+import com.devcourse.checkmoi.domain.user.model.UserRole;
+import com.devcourse.checkmoi.domain.user.model.vo.Email;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public abstract class EntityGeneratorUtil {
+
+    public static StudyMember makeStudyMember(Study study, User user, StudyMemberStatus status) {
+        return StudyMember.builder()
+            .status(status)
+            .user(user)
+            .study(study)
+            .build();
+    }
+
+    public static Study makeStudy(Book book) {
+        String name = UUID.randomUUID().toString().substring(20);
+        return Study.builder()
+            .name("스터디-" + name)
+            .thumbnailUrl("https://example.com/java.png")
+            .description("자바 스터디")
+            .maxParticipant(3)
+            .status(StudyStatus.RECRUTING)
+            .book(book)
+            .gatherStartDate(LocalDate.now())
+            .gatherEndDate(LocalDate.now())
+            .studyStartDate(LocalDate.now())
+            .studyEndDate(LocalDate.now())
+            .build();
+    }
+
+    public static User makeUser() {
+        String name = UUID.randomUUID().toString().substring(26);
+        return User.builder()
+            .oauthId("ASDASDQWDAASDZFWEF1")
+            .provider("KAKAO")
+            .name(name)
+            .email(new Email(name + "@test.com"))
+            .profileImgUrl("https://example.com/java.png")
+            .userRole(UserRole.LOGIN)
+            .build();
+    }
+
+    public static Book makeBook() {
+        String title = UUID.randomUUID().toString().substring(10);
+        String isbn = UUID.randomUUID().toString().substring(20);
+        return Book.builder()
+            .title(title)
+            .description("자바책")
+            .author("김자바")
+            .publisher("자바출판")
+            .isbn(isbn)
+            .thumbnail("https://example.com/java.png")
+            .publishedAt(new PublishedDate("20121111"))
+            .build();
+    }
+}


### PR DESCRIPTION
## 작업사항
### GET `/api/studies/{studyId}`
스터디 정보를 조회하면, 책 정보와 스터디에 가입된 멤버 정보를 가지고 오는 API를 제작하였습니다.

```
{
  "data": {
    "study": {
      "id": 1,
      "name": "스터디 이름",
      "thumbnailUrl": "스터디 썸네일 URL",
      "description": "스터디 설명",
      "currentParticipant": 2,
      "maxParticipant": 5,
      "gatherStartDate": "2022-08-02",
      "gatherEndDate": "2022-08-02",
      "studyStartDate": "2022-08-02",
      "studyEndDate": "2022-08-02",

      "book": {
        "bookId": 1,
        "title": "책 제목",
        "author": "책 저자",
        "publisher": "출판사",
        "thumbnail": "책 썸네일"
      }
    },
    "members": [
      {
        "id": 1,
        "name": "fa4-4dee-9060-a8bdebe2ba8b",
        "email": "asdf@asdf.com",
        "profileImageUrl": "url"
      },
      {
        "id": 2,
        "name": "b7f-477a-b92c-31f5d1c637da",
        "email": "asdf@asdf.com",
        "profileImageUrl": "url"
      }
    ]
  }
}
```

## 중점적으로 봐야할 부분
- 현재 Repository 테스트시에 Stub에 id값이 존재해서 테스트가 깨지는 현상이 발생했습니다.
그래서 id 값이 없이 생성만을 도와주는 Util 클래스를 제작하였습니다.
- StudyMember의 BaseEntity 상속하는 부분이 없어서 수정하였습니다 (이를통해 스터디장을 최상단으로 정렬 - createdAt이 먼저 된 순서)

- resolves #56 
