### PR TITLE
✨ feat : 스터디 상태를 진행중으로 상태변경시 스터디신청목록 처리

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/study/converter/StudyConverter.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/converter/StudyConverter.java
@@ -25,7 +25,7 @@ public class StudyConverter {
             .gatherEndDate(request.gatherEndDate())
             .studyStartDate(request.studyStartDate())
             .studyEndDate(request.studyEndDate())
-            .status(StudyStatus.RECRUTING)
+            .status(StudyStatus.RECRUITING)
             .build();
     }
 

--- a/src/main/java/com/devcourse/checkmoi/domain/study/exception/NotAllowedStudyStatusException.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/exception/NotAllowedStudyStatusException.java
@@ -1,0 +1,11 @@
+package com.devcourse.checkmoi.domain.study.exception;
+
+import com.devcourse.checkmoi.global.exception.BusinessException;
+import com.devcourse.checkmoi.global.exception.ErrorMessage;
+
+public class NotAllowedStudyStatusException extends BusinessException {
+
+    public NotAllowedStudyStatusException() {
+        super(ErrorMessage.NOT_ALLOWED_STUDY_STATUS);
+    }
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/Study.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/Study.java
@@ -3,6 +3,7 @@ package com.devcourse.checkmoi.domain.study.model;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 import com.devcourse.checkmoi.domain.book.model.Book;
+import com.devcourse.checkmoi.domain.study.exception.NotAllowedStudyStatusException;
 import com.devcourse.checkmoi.global.model.BaseEntity;
 import java.time.LocalDate;
 import javax.persistence.Entity;
@@ -134,6 +135,10 @@ public class Study extends BaseEntity {
     }
 
     public void changeStatus(StudyStatus status) {
+        if (!this.status.isAllowedNextStatus(status)) {
+            throw new NotAllowedStudyStatusException();
+        }
+
         this.status = status;
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyStatus.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyStatus.java
@@ -1,7 +1,7 @@
 package com.devcourse.checkmoi.domain.study.model;
 
 public enum StudyStatus {
-    RECRUTING,
+    RECRUITING,
     IN_PROGRESS,
     FINISHED
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyStatus.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyStatus.java
@@ -1,7 +1,33 @@
 package com.devcourse.checkmoi.domain.study.model;
 
+import java.util.Set;
+
 public enum StudyStatus {
-    RECRUITING,
-    IN_PROGRESS,
-    FINISHED
+    RECRUITING(
+        Set.of(NextStatus.IN_PROGRESS, NextStatus.RECRUITING)),
+    IN_PROGRESS(
+        Set.of(NextStatus.RECRUITING, NextStatus.IN_PROGRESS, NextStatus.FINISHED)),
+    FINISHED(
+        Set.of(NextStatus.FINISHED));
+
+    private final Set<NextStatus> allowedNextStatus;
+
+    StudyStatus(Set<NextStatus> allowedNextStatus) {
+        this.allowedNextStatus = allowedNextStatus;
+    }
+
+    public boolean isAllowedNextStatus(StudyStatus status) {
+        return this.allowedNextStatus.contains(NextStatus.of(status));
+    }
+
+    private enum NextStatus {
+        RECRUITING,
+        IN_PROGRESS,
+        FINISHED;
+
+        public static NextStatus of(StudyStatus status) {
+            return NextStatus.valueOf(status.name());
+        }
+
+    }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepository.java
@@ -15,4 +15,6 @@ public interface CustomStudyRepository {
     StudyDetailWithMembers getStudyInfoWithMembers(Long studyId);
 
     StudyAppliers getStudyAppliers(Long studyId);
+
+    void updateAllAppliersAsDenied(Long studyId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepositoryImpl.java
@@ -74,6 +74,15 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
             .build();
     }
 
+    @Override
+    public void updateAllAppliersAsDenied(Long studyId) {
+        jpaQueryFactory.update(studyMember)
+            .where(studyMember.study.id.eq(studyId),
+                studyMember.status.eq(StudyMemberStatus.PENDING))
+            .set(studyMember.status, StudyMemberStatus.DENIED)
+            .execute();
+    }
+
     private StudyDetailInfo getStudyInfo(Long studyId) {
         return jpaQueryFactory.select(
                 Projections.constructor(

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/study/CustomStudyRepositoryImpl.java
@@ -29,9 +29,7 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
     @Override
     public Long findStudyOwner(Long studyId) {
         return jpaQueryFactory.select(studyMember.user.id)
-            .from(study)
-            .innerJoin(studyMember)
-            .on(study.id.eq(studyMember.study.id))
+            .from(studyMember)
             .where(
                 study.id.eq(studyId),
                 studyMember.status.eq(StudyMemberStatus.OWNED)
@@ -48,7 +46,7 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
                 .limit(pageable.getPageSize())
                 .where(
                     study.book.id.eq(bookId),
-                    study.status.eq(StudyStatus.RECRUTING)
+                    study.status.eq(StudyStatus.RECRUITING)
                 )
                 .fetch()
         );

--- a/src/main/java/com/devcourse/checkmoi/global/exception/ErrorMessage.java
+++ b/src/main/java/com/devcourse/checkmoi/global/exception/ErrorMessage.java
@@ -25,7 +25,9 @@ public enum ErrorMessage {
     STUDY_JOIN_REQUEST_DUPLICATE("이미 스터디 가입 요청을 완료했습니다.", HttpStatus.CONFLICT),
 
     // file error
-    NOT_ALLOWED_FILE("허용할 수 없는 파일입니다", HttpStatus.BAD_REQUEST);
+    NOT_ALLOWED_FILE("허용할 수 없는 파일입니다", HttpStatus.BAD_REQUEST),
+
+    NOT_ALLOWED_STUDY_STATUS("스터디 상태 변경을 할 수 없습니다", HttpStatus.BAD_REQUEST);
 
     private final String message;
 

--- a/src/main/java/com/devcourse/checkmoi/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/devcourse/checkmoi/global/exception/GlobalExceptionHandler.java
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
-        log.error(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());
+        log.error(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage(), e);
 
         ErrorMessage errorMessage = e.getErrorMessage();
         ErrorResponse response = ErrorResponse.of(errorMessage);
@@ -36,7 +36,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
-        log.error(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());
+        log.error(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage(), e);
 
         ErrorResponse response = ErrorResponse.of(ErrorMessage.INTERNAL_SERVER_ERROR);
 
@@ -45,7 +45,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BindException.class)
     protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
-        log.warn(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());
+        log.warn(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage(), e);
 
         ErrorResponse response = ErrorResponse.of(e);
 

--- a/src/main/java/com/devcourse/checkmoi/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/devcourse/checkmoi/global/exception/GlobalExceptionHandler.java
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
-        log.error(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage(), e);
+        log.error(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());
 
         ErrorMessage errorMessage = e.getErrorMessage();
         ErrorResponse response = ErrorResponse.of(errorMessage);
@@ -36,7 +36,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
-        log.error(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage(), e);
+        log.error(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());
 
         ErrorResponse response = ErrorResponse.of(ErrorMessage.INTERNAL_SERVER_ERROR);
 
@@ -45,7 +45,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BindException.class)
     protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
-        log.warn(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage(), e);
+        log.warn(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());
 
         ErrorResponse response = ErrorResponse.of(e);
 

--- a/src/test/java/com/devcourse/checkmoi/domain/study/converter/StudyConverterTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/converter/StudyConverterTest.java
@@ -46,7 +46,7 @@ class StudyConverterTest {
                 .gatherEndDate(request.gatherEndDate())
                 .studyStartDate(request.studyStartDate())
                 .studyEndDate(request.studyEndDate())
-                .status(StudyStatus.RECRUTING)
+                .status(StudyStatus.RECRUITING)
                 .build();
 
             Study got = studyConverter.createToEntity(request);

--- a/src/test/java/com/devcourse/checkmoi/domain/study/model/StudyStatusTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/model/StudyStatusTest.java
@@ -1,0 +1,53 @@
+package com.devcourse.checkmoi.domain.study.model;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class StudyStatusTest {
+
+    @Test
+    @DisplayName("F 모집중이던 스터디를 진행완료로 변경할 수 없다")
+    void changeStatusToFinishedFail() {
+        StudyStatus beforeStatus = StudyStatus.RECRUITING;
+
+        boolean finished = beforeStatus.isAllowedNextStatus(StudyStatus.FINISHED);
+
+        Assertions.assertThat(finished)
+            .isFalse();
+    }
+
+    @Test
+    @DisplayName("S 모집중이던 스터디를 진행중으로 변경할 수 있다")
+    void changeStatusToInProgress() {
+        StudyStatus beforeStatus = StudyStatus.RECRUITING;
+
+        boolean finished = beforeStatus.isAllowedNextStatus(StudyStatus.IN_PROGRESS);
+
+        Assertions.assertThat(finished)
+            .isTrue();
+    }
+
+    @Test
+    @DisplayName("S 진행중이던 스터디를 모집 중으로 변경할 수 있다")
+    void changeStatusToRecruiting() {
+        StudyStatus beforeStatus = StudyStatus.IN_PROGRESS;
+
+        boolean finished = beforeStatus.isAllowedNextStatus(StudyStatus.RECRUITING);
+
+        Assertions.assertThat(finished)
+            .isTrue();
+    }
+
+    @Test
+    @DisplayName("F 진행 완료된 스터디를 진행 중으로 변경할 수 없다")
+    void changeStatusToInProgressFail() {
+        StudyStatus beforeStatus = StudyStatus.FINISHED;
+
+        boolean finished = beforeStatus.isAllowedNextStatus(StudyStatus.IN_PROGRESS);
+
+        Assertions.assertThat(finished)
+            .isFalse();
+    }
+
+}

--- a/src/test/java/com/devcourse/checkmoi/domain/study/model/StudyTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/model/StudyTest.java
@@ -1,0 +1,38 @@
+package com.devcourse.checkmoi.domain.study.model;
+
+import com.devcourse.checkmoi.domain.study.exception.NotAllowedStudyStatusException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class StudyTest {
+
+    @Nested
+    class ChangeStatusTest {
+
+        @Test
+        @DisplayName("F 진행완료된 상태를 진행 중으로 변경할 수 없다 ")
+        void changeStatusToInProgressFail() {
+            Study study = Study.builder()
+                .status(StudyStatus.FINISHED)
+                .build();
+
+            Assertions.assertThatThrownBy(() ->
+                study.changeStatus(StudyStatus.IN_PROGRESS)
+            ).isInstanceOf(NotAllowedStudyStatusException.class);
+        }
+
+        @Test
+        @DisplayName("F 모집중 상태를 완료된 상태로 변경할 수 없다 ")
+        void changeStatusToFinishedFail() {
+            Study study = Study.builder()
+                .status(StudyStatus.RECRUITING)
+                .build();
+
+            Assertions.assertThatThrownBy(() ->
+                study.changeStatus(StudyStatus.FINISHED)
+            ).isInstanceOf(NotAllowedStudyStatusException.class);
+        }
+    }
+}

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/study/StudyCommandServiceImplTest.java
@@ -17,6 +17,7 @@ import com.devcourse.checkmoi.domain.study.exception.StudyNotFoundException;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyMember;
 import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.devcourse.checkmoi.domain.study.repository.study.StudyMemberRepository;
 import com.devcourse.checkmoi.domain.study.repository.study.StudyRepository;
 import com.devcourse.checkmoi.domain.study.stub.StudyMemberStub;
@@ -117,6 +118,7 @@ class StudyCommandServiceImplTest {
             Long studyId = 1L;
             Study study = Study.builder()
                 .id(1L)
+                .status(StudyStatus.RECRUITING)
                 .build();
             when(studyRepository.findStudyOwner(anyLong()))
                 .thenReturn(userId);

--- a/src/test/java/com/devcourse/checkmoi/domain/study/stub/StudyStub.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/stub/StudyStub.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public class StudyStub {
+
     private static final List<Book> book = BookStub.StubBook();
 
     public static List<String> javaRecrutingStudyNameStub() {
@@ -25,7 +26,7 @@ public class StudyStub {
                 .thumbnailUrl("https://example.com/java.png")
                 .description("자바 스터디 1번입니다.")
                 .maxParticipant(3)
-                .status(StudyStatus.RECRUTING)
+                .status(StudyStatus.RECRUITING)
                 .book(book.get(0))
                 .gatherStartDate(LocalDate.now())
                 .gatherEndDate(LocalDate.now())
@@ -38,7 +39,7 @@ public class StudyStub {
                 .thumbnailUrl("https://example.com/java3.png")
                 .description("자바 스터디 3번입니다.")
                 .maxParticipant(3)
-                .status(StudyStatus.RECRUTING)
+                .status(StudyStatus.RECRUITING)
                 .book(book.get(0))
                 .gatherStartDate(LocalDate.now())
                 .gatherEndDate(LocalDate.now())
@@ -47,6 +48,7 @@ public class StudyStub {
                 .build()
         );
     }
+
     public static List<Study> studiesStub() {
         return List.of(
             Study.builder()
@@ -55,7 +57,7 @@ public class StudyStub {
                 .thumbnailUrl("https://example.com/java.png")
                 .description("자바 스터디 1번입니다.")
                 .maxParticipant(3)
-                .status(StudyStatus.RECRUTING)
+                .status(StudyStatus.RECRUITING)
                 .book(book.get(0))
                 .gatherStartDate(LocalDate.now())
                 .gatherEndDate(LocalDate.now())
@@ -81,7 +83,7 @@ public class StudyStub {
                 .thumbnailUrl("https://example.com/java3.png")
                 .description("자바 스터디 3번입니다.")
                 .maxParticipant(3)
-                .status(StudyStatus.RECRUTING)
+                .status(StudyStatus.RECRUITING)
                 .book(book.get(0))
                 .gatherStartDate(LocalDate.now())
                 .gatherEndDate(LocalDate.now())
@@ -94,7 +96,7 @@ public class StudyStub {
                 .thumbnailUrl("https://example.com/java.png")
                 .description("자바스크립트 스터디 1번입니다.")
                 .maxParticipant(3)
-                .status(StudyStatus.RECRUTING)
+                .status(StudyStatus.RECRUITING)
                 .book(book.get(1))
                 .gatherStartDate(LocalDate.now())
                 .gatherEndDate(LocalDate.now())
@@ -124,7 +126,7 @@ public class StudyStub {
             .thumbnailUrl("https://example.com/java.png")
             .description("자바 스터디 1번입니다.")
             .maxParticipant(3)
-            .status(StudyStatus.RECRUTING)
+            .status(StudyStatus.RECRUITING)
             .book(book.get(0))
             .gatherStartDate(LocalDate.now())
             .gatherEndDate(LocalDate.now())
@@ -140,7 +142,7 @@ public class StudyStub {
             .thumbnailUrl("https://example.com/java.png")
             .description("자바 스터디 1번입니다.")
             .maxParticipant(3)
-            .status(StudyStatus.RECRUTING)
+            .status(StudyStatus.RECRUITING)
             .book(b)
             .gatherStartDate(LocalDate.now())
             .gatherEndDate(LocalDate.now())

--- a/src/test/java/com/devcourse/checkmoi/util/EntityGeneratorUtil.java
+++ b/src/test/java/com/devcourse/checkmoi/util/EntityGeneratorUtil.java
@@ -29,7 +29,7 @@ public abstract class EntityGeneratorUtil {
             .thumbnailUrl("https://example.com/java.png")
             .description("자바 스터디")
             .maxParticipant(3)
-            .status(StudyStatus.RECRUTING)
+            .status(StudyStatus.RECRUITING)
             .book(book)
             .gatherStartDate(LocalDate.now())
             .gatherEndDate(LocalDate.now())


### PR DESCRIPTION
## 작업사항
스터디 상태를 모집중 -> 진행중으로 변경시, 아직 PENDING 중이던 스터디 신청목록을 일괄 DENIED 로 변경합니다
스터디 상태가 진행완료 -> 진행중으로 다시 변경하는 것은 막습니다

## 중점적으로 봐야할 부분
상태 변경에 대한 정책을 적용하기 위해 
StudyStatus 에 NestStudyStatus 를 추가 정의 사용하여, 현재 상태에서 변경될 수 있는 , 허용하는 다음 스터디 상태를 정의해 두는 방식을 통해 서비스 레이어에서 변화가 많이 일어나지 않도록 하였습니다. 
하지만, 모집중->진행중 으로 변경 하는 경우에 한해서는 이 경우인지를 확인하여, PENDING 상태인 신청을 모두 거절해주어야 해서 이부분은 서비스 계층에 로직을 추가했습니다. 

- resolves #96 
