### PR TITLE
♻️ refactor : 스터디 내부에서 쓰이는 유저 도메인 종속 제거

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyResponse.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyResponse.java
@@ -6,7 +6,7 @@ import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyBookInfo;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailInfo;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
-import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyUserInfo;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,7 +15,8 @@ import lombok.Builder;
 import org.springframework.data.domain.Page;
 
 public sealed interface StudyResponse permits
-    StudyInfo, StudyDetailWithMembers, Studies, StudyDetailInfo, StudyBookInfo, StudyAppliers {
+    StudyInfo, StudyDetailWithMembers, Studies, StudyDetailInfo, StudyBookInfo, StudyAppliers,
+    StudyUserInfo {
 
     record StudyInfo(
         Long id,
@@ -86,9 +87,22 @@ public sealed interface StudyResponse permits
         }
     }
 
+    record StudyUserInfo(
+        Long id,
+        String name,
+        String email,
+        Float temperature,
+        String profileImageUrl
+    ) implements StudyResponse {
+
+        @Builder
+        public StudyUserInfo {
+        }
+    }
+
     record StudyDetailWithMembers(
         StudyDetailInfo study,
-        List<UserInfo> members
+        List<StudyUserInfo> members
     ) implements StudyResponse {
 
         @Builder
@@ -108,7 +122,7 @@ public sealed interface StudyResponse permits
     }
 
     record StudyAppliers(
-        List<UserInfo> appliers
+        List<StudyUserInfo> appliers
     ) implements StudyResponse {
 
         @Builder

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepositoryImpl.java
@@ -6,10 +6,10 @@ import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyAppliers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyBookInfo;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailInfo;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyUserInfo;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
 import com.devcourse.checkmoi.domain.study.model.StudyStatus;
-import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfo;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -55,7 +55,7 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
     @Override
     public StudyDetailWithMembers getStudyInfoWithMembers(Long studyId) {
         StudyDetailInfo studyInfo = getStudyInfo(studyId);
-        List<UserInfo> memberInfo = getStudyMembers(studyId, StudyMemberStatus.ACCEPTED,
+        List<StudyUserInfo> memberInfo = getStudyMembers(studyId, StudyMemberStatus.ACCEPTED,
             StudyMemberStatus.OWNED);
 
         return StudyDetailWithMembers.builder()
@@ -67,7 +67,7 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
     @Override
     public StudyAppliers getStudyAppliers(
         Long studyId) {
-        List<UserInfo> appliers = getStudyMembers(studyId, StudyMemberStatus.PENDING, null);
+        List<StudyUserInfo> appliers = getStudyMembers(studyId, StudyMemberStatus.PENDING, null);
 
         return StudyAppliers.builder()
             .appliers(appliers)
@@ -112,11 +112,11 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
             .fetchOne();
     }
 
-    private List<UserInfo> getStudyMembers(Long studyId, StudyMemberStatus requiredStatus,
+    private List<StudyUserInfo> getStudyMembers(Long studyId, StudyMemberStatus requiredStatus,
         StudyMemberStatus optionalStatus) {
         return jpaQueryFactory.select(
                 Projections.constructor(
-                    UserInfo.class,
+                    StudyUserInfo.class,
                     studyMember.user.id,
                     studyMember.user.name,
                     studyMember.user.email.value.as("email"),

--- a/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
@@ -27,11 +27,11 @@ import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyAppliers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyBookInfo;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailInfo;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyUserInfo;
 import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.devcourse.checkmoi.domain.study.service.StudyCommandService;
 import com.devcourse.checkmoi.domain.study.service.StudyQueryService;
 import com.devcourse.checkmoi.domain.token.dto.TokenResponse.TokenWithUserInfo;
-import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfo;
 import com.devcourse.checkmoi.global.model.PageRequest;
 import com.devcourse.checkmoi.template.IntegrationTest;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
@@ -398,7 +398,7 @@ class StudyApiTest extends IntegrationTest {
         void studyDetailInfoTest() throws Exception {
 
             StudyDetailInfo givenStudyInfo = givenStudyDetailInfo(givenBookInfo());
-            List<UserInfo> givenMembers = List.of(givenUserInfo(), givenUserInfo());
+            List<StudyUserInfo> givenMembers = List.of(givenUserInfo(), givenUserInfo());
 
             StudyDetailWithMembers expected = StudyDetailWithMembers.builder()
                 .study(givenStudyInfo)
@@ -464,8 +464,8 @@ class StudyApiTest extends IntegrationTest {
                 ));
         }
 
-        private UserInfo givenUserInfo() {
-            return UserInfo.builder()
+        private StudyUserInfo givenUserInfo() {
+            return StudyUserInfo.builder()
                 .id(userId++)
                 .name(UUID.randomUUID().toString().substring(10))
                 .email("asdf@asdf.com")
@@ -551,13 +551,13 @@ class StudyApiTest extends IntegrationTest {
                 ));
         }
 
-        private List<UserInfo> userInfoList() {
+        private List<StudyUserInfo> userInfoList() {
 
             return LongStream.range(1, 3).mapToObj(this::createUserInfo).toList();
         }
 
-        private UserInfo createUserInfo(Long id) {
-            return UserInfo.builder()
+        private StudyUserInfo createUserInfo(Long id) {
+            return StudyUserInfo.builder()
                 .id(id)
                 .temperature(36.5f)
                 .email("abc" + id + "@naver.com")

--- a/src/test/java/com/devcourse/checkmoi/domain/study/repository/StudyRepositoryTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/repository/StudyRepositoryTest.java
@@ -14,10 +14,10 @@ import com.devcourse.checkmoi.domain.book.model.Book;
 import com.devcourse.checkmoi.domain.book.repository.BookRepository;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyAppliers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyUserInfo;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
 import com.devcourse.checkmoi.domain.study.model.StudyStatus;
-import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfo;
 import com.devcourse.checkmoi.domain.user.model.User;
 import com.devcourse.checkmoi.domain.user.repository.UserRepository;
 import com.devcourse.checkmoi.global.model.PageRequest;
@@ -86,7 +86,7 @@ class StudyRepositoryTest extends RepositoryTest {
 
             studyRepository.updateAllAppliersAsDenied(study.getId());
 
-            List<UserInfo> appliers = studyRepository
+            List<StudyUserInfo> appliers = studyRepository
                 .getStudyAppliers(study.getId())
                 .appliers();
 
@@ -253,7 +253,7 @@ class StudyRepositoryTest extends RepositoryTest {
         void getAllAppliersAscSuccess() {
             StudyAppliers studyAppliers = studyRepository.getStudyAppliers(study.getId());
 
-            UserInfo firstUserInfo = studyAppliers.appliers().get(0);
+            StudyUserInfo firstUserInfo = studyAppliers.appliers().get(0);
 
             Assertions.assertThat(firstUserInfo.id())
                 .isEqualTo(user1Pending.getId());

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyQueryServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyQueryServiceImplTest.java
@@ -13,12 +13,12 @@ import com.devcourse.checkmoi.domain.study.converter.StudyConverter;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyAppliers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyUserInfo;
 import com.devcourse.checkmoi.domain.study.exception.NotStudyOwnerException;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.devcourse.checkmoi.domain.study.repository.StudyRepository;
 import com.devcourse.checkmoi.domain.study.service.validator.StudyServiceValidator;
-import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfo;
 import com.devcourse.checkmoi.global.model.PageRequest;
 import java.util.List;
 import org.assertj.core.api.Assertions;
@@ -149,21 +149,21 @@ class StudyQueryServiceImplTest {
             return StudyAppliers.builder()
                 .appliers(
                     List.of(
-                        UserInfo.builder()
+                        StudyUserInfo.builder()
                             .id(1L)
                             .email("abc@naver.com")
                             .name("abc")
                             .profileImageUrl("https://south/dev/abc.png")
                             .temperature(36.5f)
                             .build(),
-                        UserInfo.builder()
+                        StudyUserInfo.builder()
                             .id(2L)
                             .email("abcd@naver.com")
                             .name("abcd")
                             .profileImageUrl("https://south/dev/abcd.png")
                             .temperature(36.5f)
                             .build(),
-                        UserInfo.builder()
+                        StudyUserInfo.builder()
                             .id(3L)
                             .email("abce@naver.com")
                             .name("abce")


### PR DESCRIPTION
## 작업사항
스터디 내부에서 유저 DTO를 사용하는 부분을 제거하고, 스터디 내부 DTO로 변경하였습니다.

## 중점적으로 봐야할 부분
- resolves #60 
