### PR TITLE
🐛 fix : 토큰 삭제 로직 수정

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/token/service/TokenService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/token/service/TokenService.java
@@ -6,7 +6,6 @@ import com.devcourse.checkmoi.domain.token.model.Token;
 import com.devcourse.checkmoi.domain.token.repository.TokenRepository;
 import com.devcourse.checkmoi.domain.user.dto.UserResponse.Register;
 import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfo;
-import com.devcourse.checkmoi.domain.user.exception.UserNotFoundException;
 import com.devcourse.checkmoi.global.security.jwt.JwtTokenProvider;
 import com.devcourse.checkmoi.global.security.jwt.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
@@ -27,6 +26,7 @@ public class TokenService {
     public TokenWithUserInfo createToken(Register user) {
         String accessToken = jwtTokenProvider.createAccessToken(user.id(), user.role());
         String refreshToken = jwtTokenProvider.createRefreshToken();
+
         Token token = tokenRepository.findTokenByUserId(user.id())
             .orElseGet(() -> tokenRepository.save(new Token(refreshToken, user.id())));
 
@@ -45,7 +45,6 @@ public class TokenService {
 
     @Transactional
     public AccessToken refreshAccessToken(String accessToken) {
-
         jwtTokenProvider.validateAccessToken(accessToken);
 
         Claims claims = jwtTokenProvider.getClaims(accessToken);
@@ -64,13 +63,11 @@ public class TokenService {
 
     @Transactional
     public void deleteTokenByUserId(Long userId) {
-        if (!tokenRepository.existsByUserId(userId)) {
-            throw new UserNotFoundException();
-        }
         tokenRepository.deleteByUserId(userId);
     }
 
     public String createTemporaryAccessToken(Long userId) {
         return jwtTokenProvider.createAccessToken(userId, "ROLE_LOGIN");
     }
+
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/token/service/TokenService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/token/service/TokenService.java
@@ -67,6 +67,10 @@ public class TokenService {
     }
 
     public String createTemporaryAccessToken(Long userId) {
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+        Token token = tokenRepository.findTokenByUserId(userId)
+            .orElseGet(() -> tokenRepository.save(new Token(refreshToken, userId)));
+        token.refresh(refreshToken);
         return jwtTokenProvider.createAccessToken(userId, "ROLE_LOGIN");
     }
 

--- a/src/main/java/com/devcourse/checkmoi/global/security/handler/OAuthAuthenticationSuccessHandler.java
+++ b/src/main/java/com/devcourse/checkmoi/global/security/handler/OAuthAuthenticationSuccessHandler.java
@@ -1,6 +1,5 @@
 package com.devcourse.checkmoi.global.security.handler;
 
-import com.devcourse.checkmoi.global.model.SuccessResponse;
 import com.devcourse.checkmoi.global.security.oauth.OAuthProvider;
 import com.devcourse.checkmoi.global.security.oauth.OAuthService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,7 +8,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -45,7 +43,7 @@ public class OAuthAuthenticationSuccessHandler implements AuthenticationSuccessH
 
             log.info("oauth token request occurred! frontUrl : " + frontUrl);
 
-            String uri = UriComponentsBuilder.fromUriString("https://checkmoi.vercel.app/login")
+            String uri = UriComponentsBuilder.fromUriString("http://localhost:3000/login")
                 .queryParam("token", tokenResponse.accessToken())
                 .build()
                 .toUriString();

--- a/src/test/java/com/devcourse/checkmoi/domain/token/service/TokenServiceTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/token/service/TokenServiceTest.java
@@ -1,0 +1,45 @@
+package com.devcourse.checkmoi.domain.token.service;
+
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeUser;
+import com.devcourse.checkmoi.domain.token.model.Token;
+import com.devcourse.checkmoi.domain.token.repository.TokenRepository;
+import com.devcourse.checkmoi.domain.user.model.User;
+import com.devcourse.checkmoi.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+class TokenServiceTest {
+
+    @Autowired
+    TokenService tokenService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    TokenRepository tokenRepository;
+
+    @Test
+    @Transactional
+    @DisplayName("저장되어있는 유저의 토큰을 삭제할 수 있다")
+    void tokenRemoveTest() {
+        User user = userRepository.save(makeUser());
+        tokenRepository.saveAndFlush(
+            Token.builder().userId(user.getId()).refreshToken("refresh").build());
+        tokenRepository.deleteByUserId(user.getId());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("저장되어있지 않은 유저의 토큰을 지우더라도 에러가 나지 않는다")
+    void tokenRemoveTest2() {
+        User user = userRepository.save(makeUser());
+        tokenRepository.saveAndFlush(
+            Token.builder().userId(user.getId()).refreshToken("refresh").build());
+        tokenRepository.deleteByUserId(20000L);
+    }
+}


### PR DESCRIPTION
## 작업사항
refresh 토큰 삭제시 해당하는 유저가 refresh 토큰 레포에 없어도 로그아웃은 정삭작동한다

## 중점적으로 봐야할 부분

- resolves #124 
