### PR TITLE
♻️ refactor : 게시글 DTO 리팩토링

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/comment/api/CommentApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/api/CommentApi.java
@@ -8,7 +8,6 @@ import com.devcourse.checkmoi.global.security.jwt.JwtAuthentication;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.lang.Nullable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,7 +23,7 @@ public class CommentApi {
     @GetMapping("/comments")
     public ResponseEntity<SuccessResponse<List<CommentInfo>>> findAllComments(
         @AuthenticationPrincipal JwtAuthentication user,
-        @Nullable Search request
+        Search request
     ) {
         return ResponseEntity.ok()
             .body(new SuccessResponse<>(commentQueryService.findAllComments(user.id(), request)));

--- a/src/main/java/com/devcourse/checkmoi/domain/comment/converter/CommentConverter.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/converter/CommentConverter.java
@@ -2,7 +2,6 @@ package com.devcourse.checkmoi.domain.comment.converter;
 
 import com.devcourse.checkmoi.domain.comment.dto.CommentResponse.CommentInfo;
 import com.devcourse.checkmoi.domain.comment.model.Comment;
-import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,12 +13,9 @@ public class CommentConverter {
             .userId(comment.getUser().getId())
             .postId(comment.getPost().getId())
             .content(comment.getContent())
-            .createdAt(convertTime(comment.getCreatedAt()))
-            .updatedAt(convertTime(comment.getUpdatedAt()))
+            .createdAt(comment.getCreatedAt())
+            .updatedAt(comment.getUpdatedAt())
             .build();
     }
 
-    private LocalDateTime convertTime(LocalDateTime time) {
-        return time == null ? LocalDateTime.now() : time;
-    }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/dto/CommentRequest.java
@@ -2,11 +2,12 @@ package com.devcourse.checkmoi.domain.comment.dto;
 
 import com.devcourse.checkmoi.domain.comment.dto.CommentRequest.Search;
 import lombok.Builder;
+import org.springframework.lang.Nullable;
 
 public sealed interface CommentRequest permits Search {
 
     record Search(
-        Long postId
+        @Nullable Long postId
     ) implements CommentRequest {
 
         @Builder

--- a/src/main/java/com/devcourse/checkmoi/domain/comment/service/CommentQueryServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/service/CommentQueryServiceImpl.java
@@ -7,8 +7,10 @@ import com.devcourse.checkmoi.domain.comment.repository.CommentRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CommentQueryServiceImpl implements CommentQueryService {
 

--- a/src/main/java/com/devcourse/checkmoi/domain/post/api/PostApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/api/PostApi.java
@@ -12,7 +12,6 @@ import com.devcourse.checkmoi.global.security.jwt.JwtAuthentication;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.lang.Nullable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,7 +34,7 @@ public class PostApi {
     @GetMapping("/posts")
     public ResponseEntity<SuccessResponse<List<PostInfo>>> findAllPosts(
         @AuthenticationPrincipal JwtAuthentication user,
-        @Nullable Search request
+        Search request
     ) {
         return ResponseEntity.ok()
             .body(new SuccessResponse<>(postQueryService.findAllByCondition(user.id(), request)));

--- a/src/main/java/com/devcourse/checkmoi/domain/post/api/PostApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/api/PostApi.java
@@ -12,6 +12,7 @@ import com.devcourse.checkmoi.global.security.jwt.JwtAuthentication;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,10 +35,10 @@ public class PostApi {
     @GetMapping("/posts")
     public ResponseEntity<SuccessResponse<List<PostInfo>>> findAllPosts(
         @AuthenticationPrincipal JwtAuthentication user,
-        @RequestBody Search request
+        @Nullable Search request
     ) {
         return ResponseEntity.ok()
-            .body(new SuccessResponse<>(postQueryService.findAllPosts(user.id(), request)));
+            .body(new SuccessResponse<>(postQueryService.findAllByCondition(user.id(), request)));
     }
 
     @GetMapping("/posts/{postId}")

--- a/src/main/java/com/devcourse/checkmoi/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/converter/PostConverter.java
@@ -6,8 +6,6 @@ import com.devcourse.checkmoi.domain.post.model.Post;
 import com.devcourse.checkmoi.domain.post.model.PostCategory;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.user.model.User;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -18,11 +16,13 @@ public class PostConverter {
             .id(post.getId())
             .title(post.getTitle())
             .content(post.getContent())
-            .category(post.getCategory().toString())
+            .category(post.getCategory())
             .studyId(post.getStudy().getId())
-            .writerId(post.getWriter().getId())
-            .createdAt(convertLocalDate(post.getCreatedAt()))
-            .updatedAt(convertLocalDate(post.getUpdatedAt()))
+            .writerName(post.getWriter().getName())
+            .writerProfileImg(post.getWriter().getProfileImgUrl())
+            .commentCount(post.getCommentCount())
+            .createdAt(post.getCreatedAt())
+            .updatedAt(post.getUpdatedAt())
             .build();
     }
 
@@ -36,7 +36,4 @@ public class PostConverter {
             .build();
     }
 
-    private LocalDate convertLocalDate(LocalDateTime time) {
-        return time == null ? LocalDate.now() : time.toLocalDate();
-    }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/dto/PostRequest.java
@@ -9,7 +9,7 @@ import org.springframework.lang.Nullable;
 public sealed interface PostRequest permits Search, Create, Edit {
 
     record Search(
-        @Nullable Long id
+        @Nullable Long studyId
     ) implements PostRequest {
 
         @Builder

--- a/src/main/java/com/devcourse/checkmoi/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/dto/PostResponse.java
@@ -1,8 +1,9 @@
 package com.devcourse.checkmoi.domain.post.dto;
 
 import com.devcourse.checkmoi.domain.post.dto.PostResponse.PostInfo;
+import com.devcourse.checkmoi.domain.post.model.PostCategory;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 public sealed interface PostResponse permits PostInfo {
@@ -11,13 +12,16 @@ public sealed interface PostResponse permits PostInfo {
         Long id,
         String title,
         String content,
-        String category,
+        PostCategory category,
         Long studyId,
-        Long writerId,
+        String writerName,
+        String writerProfileImg,
+        Integer commentCount,
+
         @JsonFormat(pattern = "yyyy/MM/dd")
-        LocalDate createdAt,
+        LocalDateTime createdAt,
         @JsonFormat(pattern = "yyyy/MM/dd")
-        LocalDate updatedAt
+        LocalDateTime updatedAt
     ) implements PostResponse {
 
         @Builder

--- a/src/main/java/com/devcourse/checkmoi/domain/post/repository/CustomPostRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/repository/CustomPostRepository.java
@@ -1,5 +1,10 @@
 package com.devcourse.checkmoi.domain.post.repository;
 
+import com.devcourse.checkmoi.domain.post.dto.PostRequest.Search;
+import com.devcourse.checkmoi.domain.post.dto.PostResponse.PostInfo;
+import java.util.List;
+
 public interface CustomPostRepository {
 
+    List<PostInfo> findAllByCondition(Long userId, Search request);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/post/repository/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/repository/CustomPostRepositoryImpl.java
@@ -36,7 +36,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
             .from(post)
             .innerJoin(post.writer)
             .where(
-                eqStudyId(userId)
+                eqStudyId(request.studyId())
             )
             .fetch();
     }

--- a/src/main/java/com/devcourse/checkmoi/domain/post/repository/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/repository/CustomPostRepositoryImpl.java
@@ -1,6 +1,12 @@
 package com.devcourse.checkmoi.domain.post.repository;
 
+import static com.devcourse.checkmoi.domain.post.model.QPost.post;
+import com.devcourse.checkmoi.domain.post.dto.PostRequest.Search;
+import com.devcourse.checkmoi.domain.post.dto.PostResponse.PostInfo;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +16,36 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
+    @Override
+    public List<PostInfo> findAllByCondition(Long userId, Search request) {
+        return jpaQueryFactory.select(
+                Projections.constructor(
+                    PostInfo.class,
+                    post.id,
+                    post.title,
+                    post.content,
+                    post.category,
+                    post.study.id,
+                    post.writer.name,
+                    post.writer.profileImgUrl,
+                    post.commentCount,
+                    post.createdAt,
+                    post.updatedAt
+                )
+            )
+            .from(post)
+            .innerJoin(post.writer)
+            .where(
+                eqStudyId(userId)
+            )
+            .fetch();
+    }
+
+    private BooleanExpression eqStudyId(Long studyId) {
+        if (studyId == null) {
+            return null;
+        }
+        return post.study.id.eq(studyId);
+    }
 
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/service/PostQueryService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface PostQueryService {
 
-    List<PostInfo> findAllPosts(Long userId, Search request);
+    List<PostInfo> findAllByCondition(Long userId, Search request);
 
     PostInfo findByPostId(Long userId, Long postId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/service/PostQueryServiceImpl.java
@@ -21,11 +21,10 @@ public class PostQueryServiceImpl implements PostQueryService {
     private final PostConverter postConverter;
 
     // TODO: validation
-    // TODO: pageable & dynamic search
+    // TODO: pageable
     @Override
-    public List<PostInfo> findAllPosts(Long userId, Search request) {
-        return postRepository.findAll().stream()
-            .map(postConverter::postToInfo).toList();
+    public List<PostInfo> findAllByCondition(Long userId, Search request) {
+        return postRepository.findAllByCondition(userId, request);
     }
 
     @Override

--- a/src/test/java/com/devcourse/checkmoi/domain/comment/service/CommentQueryServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/comment/service/CommentQueryServiceImplTest.java
@@ -27,6 +27,7 @@ import com.devcourse.checkmoi.domain.user.model.User;
 import com.devcourse.checkmoi.domain.user.repository.UserRepository;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -61,6 +62,15 @@ class CommentQueryServiceImplTest {
     @Autowired
     private CommentConverter commentConverter;
 
+    @AfterEach
+    void cleanUp() {
+        commentRepository.deleteAllInBatch();
+        postRepository.deleteAllInBatch();
+        studyMemberRepository.deleteAllInBatch();
+        studyRepository.deleteAllInBatch();
+        bookRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
 
     @Nested
     @DisplayName("작성된 글에 대한 댓글 목록 조회 #130")
@@ -115,5 +125,4 @@ class CommentQueryServiceImplTest {
                 .hasSameElementsAs(commentInfos);
         }
     }
-
 }

--- a/src/test/java/com/devcourse/checkmoi/domain/post/api/PostApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/post/api/PostApiTest.java
@@ -21,6 +21,8 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import com.devcourse.checkmoi.domain.post.converter.PostConverter;
 import com.devcourse.checkmoi.domain.post.dto.PostRequest;
@@ -49,6 +51,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 class PostApiTest extends IntegrationTest {
 
@@ -174,13 +178,15 @@ class PostApiTest extends IntegrationTest {
                 makePostWithId(GENERAL, study, user, 3L)
             ).map(postConverter::postToInfo).toList();
 
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("studyId", String.valueOf(study.getId()));
+
             given(postQueryService.findAllByCondition(anyLong(), any(Search.class)))
                 .willReturn(postInfos);
 
             mockMvc.perform(get("/api/posts")
-                    .contentType(MediaType.APPLICATION_JSON).characterEncoding("utf-8")
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + givenUser.accessToken())
-                    .content(toJson(request)))
+                    .params(params))
                 .andExpect(status().isOk())
                 .andDo(documentation());
         }
@@ -194,6 +200,9 @@ class PostApiTest extends IntegrationTest {
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 tokenRequestHeader(),
+                requestParameters(
+                    parameterWithName("studyId").description("스터디 아이디").optional()
+                ),
                 responseFields(
                     // post infos
                     fieldWithPath("data[].id").description("게시글 아이디"),

--- a/src/test/java/com/devcourse/checkmoi/domain/post/api/PostApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/post/api/PostApiTest.java
@@ -30,6 +30,7 @@ import com.devcourse.checkmoi.domain.post.dto.PostRequest.Create;
 import com.devcourse.checkmoi.domain.post.dto.PostRequest.Edit;
 import com.devcourse.checkmoi.domain.post.dto.PostRequest.Search;
 import com.devcourse.checkmoi.domain.post.dto.PostResponse.PostInfo;
+import com.devcourse.checkmoi.domain.post.model.Post;
 import com.devcourse.checkmoi.domain.post.service.PostCommandService;
 import com.devcourse.checkmoi.domain.post.service.PostQueryService;
 import com.devcourse.checkmoi.domain.study.model.Study;
@@ -41,7 +42,6 @@ import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -168,15 +168,14 @@ class PostApiTest extends IntegrationTest {
         void findAllPosts() throws Exception {
             TokenWithUserInfo givenUser = getTokenWithUserInfo();
 
-            Search request = Search.builder().build();
-
             Study study = makeStudyWithId(makeBook(), StudyStatus.IN_PROGRESS, 1L);
             User user = makeUserWithId(givenUser.userInfo().id());
-            List<PostInfo> postInfos = Stream.of(
-                makePostWithId(GENERAL, study, user, 1L),
-                makePostWithId(GENERAL, study, user, 2L),
-                makePostWithId(GENERAL, study, user, 3L)
-            ).map(postConverter::postToInfo).toList();
+
+            List<PostInfo> postInfos = List.of(
+                makePostInfos(makePostWithId(GENERAL, study, user, 1L)),
+                makePostInfos(makePostWithId(GENERAL, study, user, 2L)),
+                makePostInfos(makePostWithId(GENERAL, study, user, 3L))
+            );
 
             MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
             params.add("studyId", String.valueOf(study.getId()));
@@ -189,6 +188,21 @@ class PostApiTest extends IntegrationTest {
                     .params(params))
                 .andExpect(status().isOk())
                 .andDo(documentation());
+        }
+
+        private PostInfo makePostInfos(Post post) {
+            return PostInfo.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .category(post.getCategory())
+                .studyId(post.getStudy().getId())
+                .writerName(post.getWriter().getName())
+                .writerProfileImg(post.getWriter().getProfileImgUrl())
+                .commentCount(post.getCommentCount())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
         }
 
         private RestDocumentationResultHandler documentation() {

--- a/src/test/java/com/devcourse/checkmoi/domain/post/api/PostApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/post/api/PostApiTest.java
@@ -1,6 +1,7 @@
 package com.devcourse.checkmoi.domain.post.api;
 
 import static com.devcourse.checkmoi.domain.post.model.PostCategory.GENERAL;
+import static com.devcourse.checkmoi.domain.post.model.PostCategory.NOTICE;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeBook;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makePostWithId;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudyWithId;
@@ -36,7 +37,7 @@ import com.devcourse.checkmoi.domain.user.model.User;
 import com.devcourse.checkmoi.template.IntegrationTest;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -105,7 +106,6 @@ class PostApiTest extends IntegrationTest {
         }
     }
 
-
     @Nested
     @DisplayName("게시글을 단일 조회할 수 있다 #86")
     class FindPostTest {
@@ -120,11 +120,15 @@ class PostApiTest extends IntegrationTest {
                 .id(postId)
                 .title("샘플 제목")
                 .content("샘플 본문")
-                .category("NOTICE")
+                .category(NOTICE)
                 .studyId(1L)
-                .writerId(givenUser.userInfo().id())
-                .createdAt(LocalDate.now())
-                .updatedAt(LocalDate.now())
+
+                .writerName(givenUser.userInfo().name())
+                .writerProfileImg(givenUser.userInfo().profileImageUrl())
+                .commentCount(12)
+
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
                 .build();
 
             // TODO: IN_PROGRESS 중인 스터디에서만 포스트가 작성 가능하다
@@ -170,7 +174,7 @@ class PostApiTest extends IntegrationTest {
                 makePostWithId(GENERAL, study, user, 3L)
             ).map(postConverter::postToInfo).toList();
 
-            given(postQueryService.findAllPosts(anyLong(), any(Search.class)))
+            given(postQueryService.findAllByCondition(anyLong(), any(Search.class)))
                 .willReturn(postInfos);
 
             mockMvc.perform(get("/api/posts")
@@ -197,7 +201,9 @@ class PostApiTest extends IntegrationTest {
                     fieldWithPath("data[].content").description("게시글 본문"),
                     fieldWithPath("data[].category").description("게시글 카테고리"),
                     fieldWithPath("data[].studyId").description("게시글이 작성된 스터디"),
-                    fieldWithPath("data[].writerId").description("게시글을 작성한 유저"),
+                    fieldWithPath("data[].writerName").description("게시글을 작성한 유저 이름"),
+                    fieldWithPath("data[].writerProfileImg").description("게시글을 작성한 유저 프로필 사진"),
+                    fieldWithPath("data[].commentCount").description("게시글 댓글 수"),
                     fieldWithPath("data[].createdAt").description("게시글 작성 일자"),
                     fieldWithPath("data[].updatedAt").description("게시글 수정 일자")
                 )

--- a/src/test/java/com/devcourse/checkmoi/domain/post/converter/PostConverterTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/post/converter/PostConverterTest.java
@@ -40,9 +40,12 @@ class PostConverterTest {
             () -> assertThat(postInfo.id()).isEqualTo(post.getId()),
             () -> assertThat(postInfo.title()).isEqualTo(post.getTitle()),
             () -> assertThat(postInfo.content()).isEqualTo(post.getContent()),
-            () -> assertThat(postInfo.category()).isEqualTo(post.getCategory().toString()),
+            () -> assertThat(postInfo.category()).isEqualTo(post.getCategory()),
             () -> assertThat(postInfo.studyId()).isEqualTo(post.getStudy().getId()),
-            () -> assertThat(postInfo.writerId()).isEqualTo(post.getWriter().getId()),
+            () -> assertThat(postInfo.writerName()).isEqualTo(post.getWriter().getName()),
+            () -> assertThat(postInfo.writerProfileImg())
+                .isEqualTo(post.getWriter().getProfileImgUrl()),
+            () -> assertThat(postInfo.commentCount()).isEqualTo(post.getCommentCount()),
             () -> assertThat(postInfo).hasFieldOrProperty("createdAt"),
             () -> assertThat(postInfo).hasFieldOrProperty("updatedAt")
         );

--- a/src/test/java/com/devcourse/checkmoi/domain/post/repository/CustomPostRepositoryImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/post/repository/CustomPostRepositoryImplTest.java
@@ -1,0 +1,112 @@
+package com.devcourse.checkmoi.domain.post.repository;
+
+import static com.devcourse.checkmoi.domain.post.model.PostCategory.BOOK_REVIEW;
+import static com.devcourse.checkmoi.domain.post.model.PostCategory.GENERAL;
+import static com.devcourse.checkmoi.domain.post.model.PostCategory.NOTICE;
+import static com.devcourse.checkmoi.domain.study.model.StudyStatus.FINISHED;
+import static com.devcourse.checkmoi.domain.study.model.StudyStatus.IN_PROGRESS;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeBook;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makePost;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudy;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudyMember;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import com.devcourse.checkmoi.domain.book.model.Book;
+import com.devcourse.checkmoi.domain.book.repository.BookRepository;
+import com.devcourse.checkmoi.domain.post.converter.PostConverter;
+import com.devcourse.checkmoi.domain.post.dto.PostRequest.Search;
+import com.devcourse.checkmoi.domain.post.dto.PostResponse.PostInfo;
+import com.devcourse.checkmoi.domain.post.model.Post;
+import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import com.devcourse.checkmoi.domain.study.repository.StudyMemberRepository;
+import com.devcourse.checkmoi.domain.study.repository.StudyRepository;
+import com.devcourse.checkmoi.domain.user.model.User;
+import com.devcourse.checkmoi.domain.user.repository.UserRepository;
+import com.devcourse.checkmoi.template.RepositoryTest;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class CustomPostRepositoryImplTest extends RepositoryTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StudyRepository studyRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private StudyMemberRepository studyMemberRepository;
+
+
+    @Nested
+    @DisplayName("게시글을 다중 조회할 수 있다 #86")
+    class FindAllPostsTest {
+
+        private User user;
+
+        private Study study;
+
+        private Post post;
+
+        private PostConverter postConverter = new PostConverter();
+
+        @AfterEach
+        void cleanUp() {
+            postRepository.deleteAllInBatch();
+            studyMemberRepository.deleteAllInBatch();
+            studyRepository.deleteAllInBatch();
+            bookRepository.deleteAllInBatch();
+            userRepository.deleteAllInBatch();
+        }
+
+        @BeforeEach
+        void setGiven() {
+            Book book = bookRepository.save(makeBook());
+            // user
+            User user2 = userRepository.save(makeUser());
+            user = userRepository.save(makeUser());
+
+            // study
+            Study illegalStudy = studyRepository.save(makeStudy(book, FINISHED));
+            study = studyRepository.save(makeStudy(book, IN_PROGRESS));
+
+            // studyMember
+            studyMemberRepository.save(makeStudyMember(study, user, StudyMemberStatus.OWNED));
+            studyMemberRepository.save(makeStudyMember(study, user2, StudyMemberStatus.ACCEPTED));
+
+            // given post
+            post = postRepository.save(makePost(GENERAL, study, user));
+
+            // illegal post
+            postRepository.save(makePost(NOTICE, illegalStudy, user));
+            postRepository.save(makePost(BOOK_REVIEW, illegalStudy, user));
+
+        }
+
+        @Test
+        void findAllByCondition() {
+            Search search = Search.builder()
+                .studyId(study.getId())
+                .build();
+
+            List<PostInfo> got = postRepository.findAllByCondition(user.getId(), search);
+            assertThat(got).hasSize(1);
+            assertThat(got)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt", "updatedAt")
+                .isEqualTo(List.of(postConverter.postToInfo(post)));
+        }
+    }
+
+}

--- a/src/test/java/com/devcourse/checkmoi/domain/post/repository/CustomPostRepositoryImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/post/repository/CustomPostRepositoryImplTest.java
@@ -85,6 +85,7 @@ class CustomPostRepositoryImplTest extends RepositoryTest {
         }
 
         @Test
+        @DisplayName("S 게시글을 조건에 따라 검색할 수 있다")
         void findAllByCondition() {
             assertThat(postRepository.count()).isNotZero();
 

--- a/src/test/java/com/devcourse/checkmoi/domain/post/repository/CustomPostRepositoryImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/post/repository/CustomPostRepositoryImplTest.java
@@ -25,7 +25,6 @@ import com.devcourse.checkmoi.domain.user.model.User;
 import com.devcourse.checkmoi.domain.user.repository.UserRepository;
 import com.devcourse.checkmoi.template.RepositoryTest;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -62,15 +61,6 @@ class CustomPostRepositoryImplTest extends RepositoryTest {
 
         private PostConverter postConverter = new PostConverter();
 
-        @AfterEach
-        void cleanUp() {
-            postRepository.deleteAllInBatch();
-            studyMemberRepository.deleteAllInBatch();
-            studyRepository.deleteAllInBatch();
-            bookRepository.deleteAllInBatch();
-            userRepository.deleteAllInBatch();
-        }
-
         @BeforeEach
         void setGiven() {
             Book book = bookRepository.save(makeBook());
@@ -92,20 +82,21 @@ class CustomPostRepositoryImplTest extends RepositoryTest {
             // illegal post
             postRepository.save(makePost(NOTICE, illegalStudy, user));
             postRepository.save(makePost(BOOK_REVIEW, illegalStudy, user));
-
         }
 
         @Test
         void findAllByCondition() {
+            assertThat(postRepository.count()).isNotZero();
+
             Search search = Search.builder()
                 .studyId(study.getId())
                 .build();
 
             List<PostInfo> got = postRepository.findAllByCondition(user.getId(), search);
-            assertThat(got).hasSize(1);
+
             assertThat(got)
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt", "updatedAt")
-                .isEqualTo(List.of(postConverter.postToInfo(post)));
+                .contains(postConverter.postToInfo(post));
         }
     }
 


### PR DESCRIPTION
## 작업사항
- 반환값에 작성자 이름과 프로필 이미지 댓글 수 추가
- requestBody로 검색하던 부분 queryPrameter 형식으로 변경
- convertTime 메서드 제거

### before 
GET `/api/posts` 
body { Id = 1 }
![image](https://user-images.githubusercontent.com/41179265/183276865-13378eb6-d8d9-471d-a369-548c0102cf1b.png)

### After
GET `/api/posts?studyId=1`

![image](https://user-images.githubusercontent.com/41179265/183276792-f2edd756-822c-4ddf-9006-884c4806b560.png)

## 중점적으로 봐야할 부분

- resolves #131 
