### PR TITLE
✨  feat : 게시글 작성 서비스로직 권한검증 기능 추가 (#134)

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/book/api/BookApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/book/api/BookApi.java
@@ -1,5 +1,6 @@
 package com.devcourse.checkmoi.domain.book.api;
 
+import static com.devcourse.checkmoi.global.util.ApiUtil.generatedUri;
 import com.devcourse.checkmoi.domain.book.dto.BookRequest.CreateBook;
 import com.devcourse.checkmoi.domain.book.dto.BookResponse.BookSpecification;
 import com.devcourse.checkmoi.domain.book.dto.BookResponse.LatestAllBooks;
@@ -11,10 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,9 +35,9 @@ public class BookApi {
         @RequestBody CreateBook createRequest) {
         Long bookId = bookCommandService.save(createRequest).id();
 
-        return ResponseEntity.ok(
-            new SuccessResponse<>(bookId)
-        );
+        return ResponseEntity
+            .created(generatedUri(bookId))
+            .body(new SuccessResponse<>(bookId));
     }
 
     @GetMapping

--- a/src/main/java/com/devcourse/checkmoi/domain/post/exception/NotAllowedWriterException.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/exception/NotAllowedWriterException.java
@@ -1,0 +1,12 @@
+package com.devcourse.checkmoi.domain.post.exception;
+
+import com.devcourse.checkmoi.global.exception.BusinessException;
+import com.devcourse.checkmoi.global.exception.ErrorMessage;
+
+public class NotAllowedWriterException extends BusinessException {
+
+    public NotAllowedWriterException(String message) {
+        super(message, ErrorMessage.NOT_ALLOWED_WRITER);
+    }
+}
+

--- a/src/main/java/com/devcourse/checkmoi/domain/post/model/PostCategory.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/model/PostCategory.java
@@ -1,7 +1,26 @@
 package com.devcourse.checkmoi.domain.post.model;
 
+import com.devcourse.checkmoi.domain.post.exception.NotAllowedWriterException;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
+import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import java.util.Set;
+
 public enum PostCategory {
-    NOTICE,
-    GENERAL,
-    BOOK_REVIEW
+    NOTICE(Set.of(StudyMemberStatus.OWNED)),
+    GENERAL(Set.of(StudyMemberStatus.OWNED, StudyMemberStatus.ACCEPTED)),
+    BOOK_REVIEW(Set.of(StudyMemberStatus.OWNED, StudyMemberStatus.ACCEPTED));
+
+    private final Set<StudyMemberStatus> allowedMembers;
+
+    PostCategory(
+        Set<StudyMemberStatus> allowedMembers) {
+        this.allowedMembers = allowedMembers;
+    }
+
+    public void checkAllowedWriter(StudyMember member) {
+        if (!allowedMembers.contains(member.getStatus())) {
+            throw new NotAllowedWriterException(
+                "게시글 작성권한이 없습니다 - 요청한 게시글 카테고리 {}" + this + "요청한 멤버 : " + member.getId());
+        }
+    }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/service/PostCommandServiceImpl.java
@@ -5,8 +5,12 @@ import com.devcourse.checkmoi.domain.post.dto.PostRequest.Create;
 import com.devcourse.checkmoi.domain.post.dto.PostRequest.Edit;
 import com.devcourse.checkmoi.domain.post.exception.PostNotFoundException;
 import com.devcourse.checkmoi.domain.post.model.Post;
+import com.devcourse.checkmoi.domain.post.model.PostCategory;
 import com.devcourse.checkmoi.domain.post.repository.PostRepository;
 import com.devcourse.checkmoi.domain.post.service.validator.PostServiceValidator;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
+import com.devcourse.checkmoi.domain.study.repository.StudyMemberRepository;
+import com.devcourse.checkmoi.domain.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,13 +24,20 @@ public class PostCommandServiceImpl implements PostCommandService {
 
     private final PostRepository postRepository;
 
+    private final StudyMemberRepository studyMemberRepository;
+
     private final PostConverter postConverter;
 
     private final PostServiceValidator postValidator;
 
     @Override
     public Long createPost(Long userId, Create request) {
-        // validation
+        StudyMember studyMember = studyMemberRepository.findByUser(userId)
+            .orElseThrow(UserNotFoundException::new);
+
+        PostCategory.valueOf(request.category())
+            .checkAllowedWriter(studyMember);
+
         return postRepository.save(postConverter.createToPost(request, userId)).getId();
     }
 

--- a/src/main/java/com/devcourse/checkmoi/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/service/PostCommandServiceImpl.java
@@ -32,7 +32,7 @@ public class PostCommandServiceImpl implements PostCommandService {
 
     @Override
     public Long createPost(Long userId, Create request) {
-        StudyMember studyMember = studyMemberRepository.findByUser(userId)
+        StudyMember studyMember = studyMemberRepository.findByUserId(userId)
             .orElseThrow(UserNotFoundException::new);
 
         PostCategory.valueOf(request.category())

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/StudyMemberRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/StudyMemberRepository.java
@@ -1,11 +1,12 @@
 package com.devcourse.checkmoi.domain.study.repository;
 
 import com.devcourse.checkmoi.domain.study.model.StudyMember;
-import com.devcourse.checkmoi.domain.user.model.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
 
-    Optional<StudyMember> findByUser(User user);
+    @Query("select sm from StudyMember sm where sm.user.id = :userId")
+    Optional<StudyMember> findByUser(Long userId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/StudyMemberRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/StudyMemberRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.Query;
 public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
 
     @Query("select sm from StudyMember sm where sm.user.id = :userId")
-    Optional<StudyMember> findByUser(Long userId);
+    Optional<StudyMember> findByUserId(Long userId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImpl.java
@@ -96,7 +96,7 @@ public class StudyCommandServiceImpl implements StudyCommandService {
             .orElseThrow(StudyNotFoundException::new);
         User user = userRepository.findById(userId)
             .orElseThrow(UserNotFoundException::new);
-        StudyMember request = studyMemberRepository.findByUser(user.getId())
+        StudyMember request = studyMemberRepository.findByUserId(user.getId())
             .map(studyMember -> {
                 studyValidator.validateDuplicateStudyMemberRequest(studyMember);
                 studyMember.changeStatus(StudyMemberStatus.PENDING);

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImpl.java
@@ -96,7 +96,7 @@ public class StudyCommandServiceImpl implements StudyCommandService {
             .orElseThrow(StudyNotFoundException::new);
         User user = userRepository.findById(userId)
             .orElseThrow(UserNotFoundException::new);
-        StudyMember request = studyMemberRepository.findByUser(user)
+        StudyMember request = studyMemberRepository.findByUser(user.getId())
             .map(studyMember -> {
                 studyValidator.validateDuplicateStudyMemberRequest(studyMember);
                 studyMember.changeStatus(StudyMemberStatus.PENDING);

--- a/src/main/java/com/devcourse/checkmoi/global/exception/ErrorMessage.java
+++ b/src/main/java/com/devcourse/checkmoi/global/exception/ErrorMessage.java
@@ -29,7 +29,11 @@ public enum ErrorMessage {
     // file error
     NOT_ALLOWED_FILE("허용할 수 없는 파일입니다", HttpStatus.BAD_REQUEST),
 
-    NOT_ALLOWED_STUDY_STATUS("스터디 상태 변경을 할 수 없습니다", HttpStatus.BAD_REQUEST);
+    // study error
+    NOT_ALLOWED_STUDY_STATUS("스터디 상태 변경을 할 수 없습니다", HttpStatus.BAD_REQUEST),
+
+    // post error
+    NOT_ALLOWED_WRITER("게시글 작성 권한이 없습니다", HttpStatus.FORBIDDEN);
 
     private final String message;
 

--- a/src/test/java/com/devcourse/checkmoi/domain/book/api/BookApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/book/api/BookApiTest.java
@@ -80,7 +80,7 @@ class BookApiTest extends IntegrationTest {
                     RestDocumentationRequestBuilders.post("/api/books")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + givenUser.accessToken())
                         .contentType(MediaType.APPLICATION_JSON).characterEncoding("utf-8")
-                        .content(toJson(createRequest))).andExpect(status().isOk())
+                        .content(toJson(createRequest))).andExpect(status().isCreated())
                 .andDo(documentation())
                 .andReturn();
 

--- a/src/test/java/com/devcourse/checkmoi/domain/post/service/PostCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/post/service/PostCommandServiceImplTest.java
@@ -67,7 +67,6 @@ class PostCommandServiceImplTest {
 
         @Test
         @DisplayName("S 일반 스터디원은 자유 게시글을 작성할 수 있다")
-            //TODO: validation -> ??
         void createPost() {
             User user = makeUserWithId(1L);
             Study study = makeStudyWithId(makeBook(), IN_PROGRESS, 2L);

--- a/src/test/java/com/devcourse/checkmoi/domain/post/service/PostCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/post/service/PostCommandServiceImplTest.java
@@ -81,7 +81,7 @@ class PostCommandServiceImplTest {
                 .studyId(study.getId())
                 .build();
 
-            given(studyMemberRepository.findByUser(any()))
+            given(studyMemberRepository.findByUserId(any()))
                 .willReturn(Optional.of(studyMember));
             when(postConverter.createToPost(any(Create.class), anyLong())).thenReturn(post);
             when(postRepository.save(any(Post.class))).thenReturn(post);
@@ -108,7 +108,7 @@ class PostCommandServiceImplTest {
                 .studyId(study.getId())
                 .build();
 
-            given(studyMemberRepository.findByUser(any()))
+            given(studyMemberRepository.findByUserId(any()))
                 .willReturn(Optional.of(studyMember));
             when(postConverter.createToPost(any(Create.class), anyLong())).thenReturn(post);
             when(postRepository.save(any(Post.class))).thenReturn(post);
@@ -133,7 +133,7 @@ class PostCommandServiceImplTest {
                 .studyId(study.getId())
                 .build();
 
-            given(studyMemberRepository.findByUser(any()))
+            given(studyMemberRepository.findByUserId(any()))
                 .willReturn(Optional.of(studyMember));
             when(postConverter.createToPost(any(Create.class), anyLong())).thenReturn(post);
             when(postRepository.save(any(Post.class))).thenReturn(post);
@@ -158,7 +158,7 @@ class PostCommandServiceImplTest {
                 .studyId(study.getId())
                 .build();
 
-            given(studyMemberRepository.findByUser(any()))
+            given(studyMemberRepository.findByUserId(any()))
                 .willReturn(Optional.of(studyMember));
 
             Assertions.assertThatThrownBy(() ->

--- a/src/test/java/com/devcourse/checkmoi/domain/post/service/PostCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/post/service/PostCommandServiceImplTest.java
@@ -4,12 +4,14 @@ import static com.devcourse.checkmoi.domain.post.model.PostCategory.GENERAL;
 import static com.devcourse.checkmoi.domain.study.model.StudyStatus.IN_PROGRESS;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeBook;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makePostWithId;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudyMember;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudyWithId;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeUserWithId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -19,13 +21,19 @@ import com.devcourse.checkmoi.domain.post.converter.PostConverter;
 import com.devcourse.checkmoi.domain.post.dto.PostRequest;
 import com.devcourse.checkmoi.domain.post.dto.PostRequest.Create;
 import com.devcourse.checkmoi.domain.post.dto.PostRequest.Edit;
+import com.devcourse.checkmoi.domain.post.exception.NotAllowedWriterException;
 import com.devcourse.checkmoi.domain.post.exception.PostNoPermissionException;
 import com.devcourse.checkmoi.domain.post.model.Post;
+import com.devcourse.checkmoi.domain.post.model.PostCategory;
 import com.devcourse.checkmoi.domain.post.repository.PostRepository;
 import com.devcourse.checkmoi.domain.post.service.validator.PostServiceValidator;
 import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
+import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import com.devcourse.checkmoi.domain.study.repository.StudyMemberRepository;
 import com.devcourse.checkmoi.domain.user.model.User;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -44,21 +52,26 @@ class PostCommandServiceImplTest {
     private PostRepository postRepository;
 
     @Mock
+    private StudyMemberRepository studyMemberRepository;
+
+    @Mock
     private PostConverter postConverter;
 
     @Mock
     private PostServiceValidator postValidator;
+
 
     @Nested
     @DisplayName("게시글을 작성할 수 있다 #86")
     class CreatePostTest {
 
         @Test
-        @DisplayName("S 게시글을 작성할 수 있다")
-            //TODO: validation
+        @DisplayName("S 일반 스터디원은 자유 게시글을 작성할 수 있다")
+            //TODO: validation -> ??
         void createPost() {
             User user = makeUserWithId(1L);
             Study study = makeStudyWithId(makeBook(), IN_PROGRESS, 2L);
+            StudyMember studyMember = makeStudyMember(study, user, StudyMemberStatus.ACCEPTED);
             Post post = makePostWithId(GENERAL, study, user, 3L);
 
             PostRequest.Create request = Create.builder()
@@ -68,6 +81,8 @@ class PostCommandServiceImplTest {
                 .studyId(study.getId())
                 .build();
 
+            given(studyMemberRepository.findByUser(any()))
+                .willReturn(Optional.of(studyMember));
             when(postConverter.createToPost(any(Create.class), anyLong())).thenReturn(post);
             when(postRepository.save(any(Post.class))).thenReturn(post);
 
@@ -78,6 +93,78 @@ class PostCommandServiceImplTest {
             then(postConverter).should(times(1)).createToPost(request, user.getId());
         }
 
+        @Test
+        @DisplayName("S 스터디장은 일반 게시글을 작성할 수 있다")
+        void createPostAsLeader() {
+            User user = makeUserWithId(1L);
+            Study study = makeStudyWithId(makeBook(), IN_PROGRESS, 2L);
+            StudyMember studyMember = makeStudyMember(study, user, StudyMemberStatus.OWNED);
+            Post post = makePostWithId(PostCategory.GENERAL, study, user, 3L);
+
+            PostRequest.Create request = Create.builder()
+                .title(post.getTitle())
+                .content(post.getContent())
+                .category(post.getCategory().toString())
+                .studyId(study.getId())
+                .build();
+
+            given(studyMemberRepository.findByUser(any()))
+                .willReturn(Optional.of(studyMember));
+            when(postConverter.createToPost(any(Create.class), anyLong())).thenReturn(post);
+            when(postRepository.save(any(Post.class))).thenReturn(post);
+
+            Long result = postCommandService.createPost(user.getId(), request);
+
+            assertThat(result).isEqualTo(post.getId());
+        }
+
+        @Test
+        @DisplayName("S 스터디장은 공지글을 작성할 수 있다")
+        void createNoticePost() {
+            User user = makeUserWithId(1L);
+            Study study = makeStudyWithId(makeBook(), IN_PROGRESS, 2L);
+            StudyMember studyMember = makeStudyMember(study, user, StudyMemberStatus.OWNED);
+            Post post = makePostWithId(PostCategory.NOTICE, study, user, 3L);
+
+            PostRequest.Create request = Create.builder()
+                .title(post.getTitle())
+                .content(post.getContent())
+                .category(post.getCategory().toString())
+                .studyId(study.getId())
+                .build();
+
+            given(studyMemberRepository.findByUser(any()))
+                .willReturn(Optional.of(studyMember));
+            when(postConverter.createToPost(any(Create.class), anyLong())).thenReturn(post);
+            when(postRepository.save(any(Post.class))).thenReturn(post);
+
+            Long result = postCommandService.createPost(user.getId(), request);
+
+            assertThat(result).isEqualTo(post.getId());
+        }
+
+        @Test
+        @DisplayName("F 일반 스터디원은 공지를 작성할 수 없다")
+        void createNoticePostFail() {
+            User user = makeUserWithId(1L);
+            Study study = makeStudyWithId(makeBook(), IN_PROGRESS, 2L);
+            StudyMember studyMember = makeStudyMember(study, user, StudyMemberStatus.ACCEPTED);
+            Post post = makePostWithId(PostCategory.NOTICE, study, user, 3L);
+
+            PostRequest.Create request = Create.builder()
+                .title(post.getTitle())
+                .content(post.getContent())
+                .category(post.getCategory().toString())
+                .studyId(study.getId())
+                .build();
+
+            given(studyMemberRepository.findByUser(any()))
+                .willReturn(Optional.of(studyMember));
+
+            Assertions.assertThatThrownBy(() ->
+                postCommandService.createPost(user.getId(), request)
+            ).isInstanceOf(NotAllowedWriterException.class);
+        }
     }
 
     @Nested

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
@@ -321,7 +321,7 @@ class StudyCommandServiceImplTest {
                 .willReturn(Optional.of(study));
             given(userRepository.findById(anyLong()))
                 .willReturn(Optional.of(user));
-            given(studyMemberRepository.findByUser(any(User.class)))
+            given(studyMemberRepository.findByUser(anyLong()))
                 .willReturn(Optional.empty());
             given(studyMemberRepository.save(any(StudyMember.class)))
                 .willReturn(studyMember);
@@ -344,7 +344,7 @@ class StudyCommandServiceImplTest {
                 .willReturn(Optional.of(study));
             given(userRepository.findById(anyLong()))
                 .willReturn(Optional.of(user));
-            given(studyMemberRepository.findByUser(any(User.class)))
+            given(studyMemberRepository.findByUser(anyLong()))
                 .willReturn(Optional.of(studyMember));
             given(studyMemberRepository.save(any(StudyMember.class)))
                 .willReturn(studyMember);
@@ -402,7 +402,7 @@ class StudyCommandServiceImplTest {
                 .willReturn(Optional.of(study));
             given(userRepository.findById(anyLong()))
                 .willReturn(Optional.of(user));
-            given(studyMemberRepository.findByUser(any(User.class)))
+            given(studyMemberRepository.findByUser(anyLong()))
                 .willReturn(Optional.of(studyMember));
 
             doThrow(new DuplicateStudyJoinRequestException(STUDY_JOIN_REQUEST_DUPLICATE))

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
@@ -321,7 +321,7 @@ class StudyCommandServiceImplTest {
                 .willReturn(Optional.of(study));
             given(userRepository.findById(anyLong()))
                 .willReturn(Optional.of(user));
-            given(studyMemberRepository.findByUser(anyLong()))
+            given(studyMemberRepository.findByUserId(anyLong()))
                 .willReturn(Optional.empty());
             given(studyMemberRepository.save(any(StudyMember.class)))
                 .willReturn(studyMember);
@@ -344,7 +344,7 @@ class StudyCommandServiceImplTest {
                 .willReturn(Optional.of(study));
             given(userRepository.findById(anyLong()))
                 .willReturn(Optional.of(user));
-            given(studyMemberRepository.findByUser(anyLong()))
+            given(studyMemberRepository.findByUserId(anyLong()))
                 .willReturn(Optional.of(studyMember));
             given(studyMemberRepository.save(any(StudyMember.class)))
                 .willReturn(studyMember);
@@ -402,7 +402,7 @@ class StudyCommandServiceImplTest {
                 .willReturn(Optional.of(study));
             given(userRepository.findById(anyLong()))
                 .willReturn(Optional.of(user));
-            given(studyMemberRepository.findByUser(anyLong()))
+            given(studyMemberRepository.findByUserId(anyLong()))
                 .willReturn(Optional.of(studyMember));
 
             doThrow(new DuplicateStudyJoinRequestException(STUDY_JOIN_REQUEST_DUPLICATE))


### PR DESCRIPTION
## 작업사항
- 스터디 장이 아닌 스터디원이 공지를 작성하려 할 경우 아래와 같은 에러를 발생시킵니다 
![image](https://user-images.githubusercontent.com/53856184/183286711-ab8dd776-027a-4aed-a4b5-6541a394fb7d.png)
- 책 등록 api 가 POST 로 변경됨에 따라 Location header 를 포함한 응답을 보내는 부분을 추가하였습니다 

## 중점적으로 봐야할 부분
- StudyMemberRepository 에 대해 기존의 findByUser 를 findByUserId 로 변경하였습니다. 저는 쿼리메소드로 작성했는데 QueryDsl 로 작성하는게 좋을까요?

## 궁금한 부분
- @kimziou77 님 //TODO  validation 이건 어떤 검증로직을 TODO 로 등록하신 걸까요?? 주석이 많이 있는데 각각의 의미가 어떤 것들인지 잘 모르겠어 일단 남겨두었습니다

- resolves #134 
