### PR TITLE
🔧 chore : yml을 통해 시큐리티 설정 정보 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,6 @@ dependencies {
     runtimeOnly 'mysql:mysql-connector-java'
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
-
     // aws s3
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.267'
 
@@ -74,6 +73,9 @@ dependencies {
 
     // Restdocs -> Swagger
     testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.2'
+
+    // @ConfigurationProperties
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
 }
 
@@ -117,7 +119,6 @@ jacocoTestCoverageVerification {
                     "com.devcourse.checkmoi.domain.*.model.vo.Q*",
                     "com.devcourse.checkmoi.domain.user.*",
                     "com.devcourse.checkmoi.domain.token.*"
-
             ]
         }
     }

--- a/src/main/java/com/devcourse/checkmoi/global/config/SecurityConfig.java
+++ b/src/main/java/com/devcourse/checkmoi/global/config/SecurityConfig.java
@@ -1,10 +1,19 @@
-package com.devcourse.checkmoi.global.security.config;
+package com.devcourse.checkmoi.global.config;
 
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.OPTIONS;
+import static org.springframework.http.HttpMethod.PATCH;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpMethod.PUT;
+import com.devcourse.checkmoi.global.config.properties.SecurityConfigProperties;
 import com.devcourse.checkmoi.global.security.handler.ExceptionHandlerFilter;
 import com.devcourse.checkmoi.global.security.handler.JwtAuthenticationEntryPoint;
 import com.devcourse.checkmoi.global.security.handler.OAuthAuthenticationSuccessHandler;
 import com.devcourse.checkmoi.global.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -15,8 +24,9 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequest
 import org.springframework.security.web.SecurityFilterChain;
 
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
 @RequiredArgsConstructor
+@EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
+@EnableConfigurationProperties(SecurityConfigProperties.class)
 public class SecurityConfig {
 
     private final OAuthAuthenticationSuccessHandler oAuth2SuccessHandler;
@@ -27,10 +37,18 @@ public class SecurityConfig {
 
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
+    private final SecurityConfigProperties securityConfigProperties;
+
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
-            .antMatchers("/static/**", "/favicon.ico", "/api/tokens/**");
+            .antMatchers(securityConfigProperties.patterns().ignoring().get("ALL"))
+            .antMatchers(GET, securityConfigProperties.patterns().ignoring().get("GET"))
+            .antMatchers(PUT, securityConfigProperties.patterns().ignoring().get("PUT"))
+            .antMatchers(POST, securityConfigProperties.patterns().ignoring().get("POST"))
+            .antMatchers(PATCH, securityConfigProperties.patterns().ignoring().get("PATCH"))
+            .antMatchers(DELETE, securityConfigProperties.patterns().ignoring().get("DELETE"))
+            .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
     }
 
     @Bean
@@ -42,7 +60,21 @@ public class SecurityConfig {
 
             // permission
             .authorizeHttpRequests()
-            .anyRequest().permitAll()
+            .antMatchers(
+                securityConfigProperties.patterns().permitAll().get("ALL")).permitAll()
+            .antMatchers(GET,
+                securityConfigProperties.patterns().permitAll().get("GET")).permitAll()
+            .antMatchers(PUT,
+                securityConfigProperties.patterns().permitAll().get("PUT")).permitAll()
+            .antMatchers(POST,
+                securityConfigProperties.patterns().permitAll().get("POST")).permitAll()
+            .antMatchers(PATCH,
+                securityConfigProperties.patterns().permitAll().get("PATCH")).permitAll()
+            .antMatchers(DELETE,
+                securityConfigProperties.patterns().permitAll().get("DELETE")).permitAll()
+            .antMatchers(OPTIONS,
+                securityConfigProperties.patterns().permitAll().get("OPTIONS")).permitAll()
+            .anyRequest().authenticated()
             .and()
 
             // oauth

--- a/src/main/java/com/devcourse/checkmoi/global/config/WebConfig.java
+++ b/src/main/java/com/devcourse/checkmoi/global/config/WebConfig.java
@@ -7,26 +7,29 @@ import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.devcourse.checkmoi.domain.file.service.S3Upload;
+import com.devcourse.checkmoi.global.config.properties.AwsConfigProperties;
+import com.devcourse.checkmoi.global.config.properties.CorsConfigProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(CorsConfigProperties.class)
 public class WebConfig implements WebMvcConfigurer {
+
+    private final CorsConfigProperties corsConfigProperties;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry
-            .addMapping("/**")
-            .allowedOrigins(
-                "http://localhost:3000",
-                "https://checkmoi.vercel.app",
-                "http://localhost:6006"
-            )
-            .allowedMethods("*")
-            .allowCredentials(true)
-            .allowedHeaders("*")
+            .addMapping(corsConfigProperties.api())
+            .allowedOrigins(corsConfigProperties.origin())
+            .allowedMethods(corsConfigProperties.method())
+            .allowCredentials(true).maxAge(3600)
             .exposedHeaders(LOCATION);
     }
 

--- a/src/main/java/com/devcourse/checkmoi/global/config/properties/AwsConfigProperties.java
+++ b/src/main/java/com/devcourse/checkmoi/global/config/properties/AwsConfigProperties.java
@@ -1,4 +1,4 @@
-package com.devcourse.checkmoi.global.config;
+package com.devcourse.checkmoi.global.config.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/devcourse/checkmoi/global/config/properties/CorsConfigProperties.java
+++ b/src/main/java/com/devcourse/checkmoi/global/config/properties/CorsConfigProperties.java
@@ -1,0 +1,14 @@
+package com.devcourse.checkmoi.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "cors.allowed")
+public record CorsConfigProperties(
+    String api,
+    String[] origin,
+    String[] method
+) {
+
+}

--- a/src/main/java/com/devcourse/checkmoi/global/config/properties/SecurityConfigProperties.java
+++ b/src/main/java/com/devcourse/checkmoi/global/config/properties/SecurityConfigProperties.java
@@ -1,0 +1,19 @@
+package com.devcourse.checkmoi.global.config.properties;
+
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "security")
+public record SecurityConfigProperties(PatternsConfigures patterns) {
+
+    public SecurityConfigProperties(PatternsConfigures patterns) {
+        this.patterns = patterns;
+    }
+
+    public record PatternsConfigures(Map<String, String[]> ignoring,
+                                     Map<String, String[]> permitAll) {
+
+    }
+}

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -51,6 +51,8 @@ security:
       GET:
         - /docs/**
         - /api/tokens/**
+        - /api/books/**
+        - /api/studies
       POST: [ ]
       PATCH: [ ]
       PUT: [ ]

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -25,3 +25,34 @@ jwt:
     expire-length: 3600000
   refresh-token:
     expire-length: 7200000
+
+cors:
+  allowed:
+    api: /**
+    method: '*'
+    origin:
+      - http://localhost:3000
+      - https://checkmoi.vercel.app
+      - http://localhost:6006
+
+security:
+  patterns:
+    ignoring:
+      ALL:
+        - /static/**
+        - /favicon.ico
+      GET: [ ]
+      POST: [ ]
+      PATCH: [ ]
+      PUT: [ ]
+      DELETE: [ ]
+    permit-all:
+      ALL: [ ]
+      GET:
+        - /docs/**
+        - /api/tokens/**
+      POST: [ ]
+      PATCH: [ ]
+      PUT: [ ]
+      DELETE: [ ]
+      OPTIONS: /**

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -55,23 +55,31 @@ cloud:
 
 cors:
   allowed:
-    api: test
-    method: test
-    origin: test
+    api: /**
+    method: '*'
+    origin:
+      - http://localhost:8080
 
 security:
   patterns:
     ignoring:
-      ALL: [ ]
+      ALL:
+        - /static/**
+        - /favicon.ico
       GET: [ ]
       POST: [ ]
       PATCH: [ ]
       PUT: [ ]
       DELETE: [ ]
     permit-all:
-      GET: [ ]
+      ALL: [ ]
+      GET:
+        - /docs/**
+        - /api/tokens/**
+        - /api/books/**
+        - /api/studies
       POST: [ ]
       PATCH: [ ]
       PUT: [ ]
       DELETE: [ ]
-      OPTIONS: [ ]
+      OPTIONS: /**

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -52,3 +52,26 @@ cloud:
       secretKey: ${S3_SECRET_KEY}
       url: ${S3_URL}
       bucketName: ${S3_INTEGRATED_BUCKET_NAME}
+
+cors:
+  allowed:
+    api: test
+    method: test
+    origin: test
+
+security:
+  patterns:
+    ignoring:
+      ALL: [ ]
+      GET: [ ]
+      POST: [ ]
+      PATCH: [ ]
+      PUT: [ ]
+      DELETE: [ ]
+    permit-all:
+      GET: [ ]
+      POST: [ ]
+      PATCH: [ ]
+      PUT: [ ]
+      DELETE: [ ]
+      OPTIONS: [ ]


### PR DESCRIPTION
## 작업사항
기존에 코드를 수정해야 변경할 수 있었던 시큐리티 자원 설정 부분을 yml 변경만을 통해 변경할 수 있도록 수정했습니다.

- **허용하는 origin은 cors.allowed.origin에 작성합니다**
![image](https://user-images.githubusercontent.com/41179265/183292058-eed00c15-cd7c-4c5a-aba0-faa99275ead5.png)

---

- **필터를 무시하는 리소스는 `security.patterns.ignoring` 에 작성합니다**
![image](https://user-images.githubusercontent.com/41179265/183292224-332502c4-1d66-48cb-8069-781a28bf101c.png)

- **로그인이 필요없는 요청은 `security.patterns.permit-all` 에 작성합니다**
![image](https://user-images.githubusercontent.com/41179265/183292210-d9874044-5ffc-4a00-84bd-c7d2faef9387.png)

## 중점적으로 봐야할 부분
스웨거 토큰 입력시 정상 작동합니다

- resolves #142 
