### PR TITLE
🐛 fix : 데이터 중복 조회 제거

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepositoryImpl.java
@@ -17,7 +17,6 @@ import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQuery;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -56,34 +55,15 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
                 eqBookId(search.bookId()),
                 eqStudyMemberStatus(search.memberStatus()),
                 eqStudyStatus(search.studyStatus())
-            );
-        long totalCount = query.fetchCount();
-        List<StudyInfo> studies = jpaQueryFactory.select(
-                Projections.constructor(
-                    StudyInfo.class,
-                    study.id,
-                    study.name,
-                    study.thumbnailUrl,
-                    study.description,
-                    study.status,
-                    study.currentParticipant, study.maxParticipant,
-                    study.gatherStartDate, study.gatherEndDate,
-                    study.studyStartDate, study.studyEndDate
-                )
             )
-            .from(study)
-            .innerJoin(studyMember)
-            .on(study.id.eq(studyMember.study.id))
+            .groupBy(study.id);
+
+        List<StudyInfo> studies = query
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
-            .where(
-                eqUserId(search.userId()),
-                eqStudyId(search.studyId()),
-                eqBookId(search.bookId()),
-                eqStudyMemberStatus(search.memberStatus()),
-                eqStudyStatus(search.studyStatus())
-            )
             .fetch();
+
+        long totalCount = query.fetchCount();
         return new PageImpl<>(studies, pageable, totalCount);
     }
 
@@ -113,22 +93,13 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
                 study.book.id.eq(bookId),
                 study.status.eq(StudyStatus.RECRUITING)
             );
-        long totalCount = query.fetchCount();
-        List<StudyInfo> studies = jpaQueryFactory.select(
-                Projections.constructor(
-                    StudyInfo.class,
-                    study.id, study.name, study.thumbnailUrl, study.description, study.status,
-                    study.currentParticipant, study.maxParticipant,
-                    study.gatherStartDate, study.gatherEndDate,
-                    study.studyStartDate, study.studyEndDate
-                ))
-            .from(study)
+        
+        List<StudyInfo> studies = query
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
-            .where(
-                study.book.id.eq(bookId),
-                study.status.eq(StudyStatus.RECRUITING)
-            ).fetch();
+            .fetch();
+
+        long totalCount = query.fetchCount();
         return new PageImpl<>(studies, pageable, totalCount);
     }
 


### PR DESCRIPTION
## 작업사항
스터디 검색시 데이터가 중복으로 조회되는 문제를 해결

## 중점적으로 봐야할 부분
현재 group by studyId를 통해서 해결하였습니다. 다른 방안이 있을까요? 🤔 

- resolves #163 
