### PR TITLE
✨ feat : 스터디에 모집완료 상태 추가 에 따른 상태 변경 제약 로직 수정 및 테스트 (#168)

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/Study.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/Study.java
@@ -135,7 +135,7 @@ public class Study extends BaseEntity {
     }
 
     public void changeStatus(StudyStatus status) {
-        if (!this.status.isAllowedNextStatus(status)) {
+        if (!this.status.isAllowedToChangeStatus(status)) {
             throw new NotAllowedStudyStatusException();
         }
 

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyStatus.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyStatus.java
@@ -1,14 +1,17 @@
 package com.devcourse.checkmoi.domain.study.model;
 
+import java.util.Collections;
 import java.util.Set;
 
 public enum StudyStatus {
     RECRUITING(
-        Set.of(NextStatus.IN_PROGRESS, NextStatus.RECRUITING)),
+        Set.of(NextStatus.IN_PROGRESS, NextStatus.RECRUITING_FINISHED)),
+    RECRUITING_FINISHED(
+        Set.of(NextStatus.IN_PROGRESS)),
     IN_PROGRESS(
-        Set.of(NextStatus.RECRUITING, NextStatus.IN_PROGRESS, NextStatus.FINISHED)),
+        Set.of(NextStatus.FINISHED)),
     FINISHED(
-        Set.of(NextStatus.FINISHED));
+        Collections.emptySet());
 
     private final Set<NextStatus> allowedNextStatus;
 
@@ -16,12 +19,23 @@ public enum StudyStatus {
         this.allowedNextStatus = allowedNextStatus;
     }
 
-    public boolean isAllowedNextStatus(StudyStatus status) {
-        return this.allowedNextStatus.contains(NextStatus.of(status));
+    public boolean isAllowedToChangeStatus(StudyStatus status) {
+        return this.isUnchanged(status) ||
+            this.isAllowedNextStatus(status);
+    }
+
+    private boolean isUnchanged(StudyStatus status) {
+        return this == status;
+    }
+
+    private boolean isAllowedNextStatus(StudyStatus status) {
+        return !this.allowedNextStatus.isEmpty() &&
+            this.allowedNextStatus.contains(NextStatus.of(status));
     }
 
     private enum NextStatus {
         RECRUITING,
+        RECRUITING_FINISHED,
         IN_PROGRESS,
         FINISHED;
 

--- a/src/test/java/com/devcourse/checkmoi/domain/study/model/StudyStatusTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/model/StudyStatusTest.java
@@ -11,7 +11,7 @@ class StudyStatusTest {
     void changeStatusToFinishedFail() {
         StudyStatus beforeStatus = StudyStatus.RECRUITING;
 
-        boolean finished = beforeStatus.isAllowedNextStatus(StudyStatus.FINISHED);
+        boolean finished = beforeStatus.isAllowedToChangeStatus(StudyStatus.FINISHED);
 
         Assertions.assertThat(finished)
             .isFalse();
@@ -22,18 +22,84 @@ class StudyStatusTest {
     void changeStatusToInProgress() {
         StudyStatus beforeStatus = StudyStatus.RECRUITING;
 
-        boolean finished = beforeStatus.isAllowedNextStatus(StudyStatus.IN_PROGRESS);
+        boolean finished = beforeStatus.isAllowedToChangeStatus(StudyStatus.IN_PROGRESS);
 
         Assertions.assertThat(finished)
             .isTrue();
     }
 
     @Test
-    @DisplayName("S 진행중이던 스터디를 모집 중으로 변경할 수 있다")
+    @DisplayName("S 모집중이던 스터디를 모집마감으로 변경할 수 있다")
+    void changeStatusToRecruitingFinished() {
+        StudyStatus beforeStatus = StudyStatus.RECRUITING;
+
+        boolean finished = beforeStatus.isAllowedToChangeStatus(StudyStatus.RECRUITING_FINISHED);
+
+        Assertions.assertThat(finished)
+            .isTrue();
+    }
+
+    @Test
+    @DisplayName("F 모집 마감 스터디를 모집 중으로 변경할 수 없다")
+    void changeRecruitingFinishedToRecruitingFail() {
+        StudyStatus beforeStatus = StudyStatus.RECRUITING_FINISHED;
+
+        boolean finished = beforeStatus.isAllowedToChangeStatus(StudyStatus.RECRUITING);
+
+        Assertions.assertThat(finished)
+            .isFalse();
+    }
+
+    @Test
+    @DisplayName("S 모집 마감 스터디를 진행 중으로 변경할 수 있다")
+    void changeRecruitingFinishedToInProgress() {
+        StudyStatus beforeStatus = StudyStatus.RECRUITING_FINISHED;
+
+        boolean finished = beforeStatus.isAllowedToChangeStatus(StudyStatus.IN_PROGRESS);
+
+        Assertions.assertThat(finished)
+            .isTrue();
+    }
+
+    @Test
+    @DisplayName("F 모집 마감 스터디를 진행 완료로 변경할 수 없다")
+    void changeRecruitingFinishedToFinishedFail() {
+        StudyStatus beforeStatus = StudyStatus.RECRUITING_FINISHED;
+
+        boolean finished = beforeStatus.isAllowedToChangeStatus(StudyStatus.FINISHED);
+
+        Assertions.assertThat(finished)
+            .isFalse();
+    }
+
+    @Test
+    @DisplayName("F 진행중이던 스터디를 모집 중으로 변경할 수 없다")
     void changeStatusToRecruiting() {
         StudyStatus beforeStatus = StudyStatus.IN_PROGRESS;
 
-        boolean finished = beforeStatus.isAllowedNextStatus(StudyStatus.RECRUITING);
+        boolean finished = beforeStatus.isAllowedToChangeStatus(StudyStatus.RECRUITING);
+
+        Assertions.assertThat(finished)
+            .isFalse();
+    }
+
+    @Test
+    @DisplayName("F 진행중이던 스터디를 모집 마감으로 변경할 수 없다")
+    void changeInProgressToRecruiting() {
+        StudyStatus beforeStatus = StudyStatus.IN_PROGRESS;
+
+        boolean finished = beforeStatus.isAllowedToChangeStatus(StudyStatus.RECRUITING_FINISHED);
+
+        Assertions.assertThat(finished)
+            .isFalse();
+    }
+
+    @Test
+    @DisplayName("S 진행중이던 스터디를 진행 완료로 변경할 수 있다")
+    void changeInProgressToFinished() {
+        StudyStatus beforeStatus = StudyStatus.IN_PROGRESS;
+
+        boolean finished = beforeStatus.isAllowedToChangeStatus(StudyStatus.FINISHED);
 
         Assertions.assertThat(finished)
             .isTrue();
@@ -44,7 +110,7 @@ class StudyStatusTest {
     void changeStatusToInProgressFail() {
         StudyStatus beforeStatus = StudyStatus.FINISHED;
 
-        boolean finished = beforeStatus.isAllowedNextStatus(StudyStatus.IN_PROGRESS);
+        boolean finished = beforeStatus.isAllowedToChangeStatus(StudyStatus.IN_PROGRESS);
 
         Assertions.assertThat(finished)
             .isFalse();

--- a/src/test/java/com/devcourse/checkmoi/domain/study/model/StudyTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/model/StudyTest.java
@@ -34,5 +34,17 @@ class StudyTest {
                 study.changeStatus(StudyStatus.FINISHED)
             ).isInstanceOf(NotAllowedStudyStatusException.class);
         }
+
+        @Test
+        @DisplayName("S 모집 중 상태를 진행 완료 상태로 변경할 수 있다 ")
+        void changeStatusToInProgress() {
+            Study study = Study.builder()
+                .status(StudyStatus.RECRUITING)
+                .build();
+
+            Assertions.assertThatNoException()
+                .isThrownBy(() ->
+                    study.changeStatus(StudyStatus.IN_PROGRESS));
+        }
     }
 }


### PR DESCRIPTION
## 작업사항
- 스터디 상태에 "모집완료" 가 추가됨에 따라, 상태 변경에 대한 제약 로직을 수정하고 이를 테스트 하였습니다

## 중점적으로 봐야할 부분
<img width="352" alt="image" src="https://user-images.githubusercontent.com/53856184/183827598-f482f491-8ce3-46d2-b78e-b09ec09b0498.png">
이에 대한 거의 대부분의 경우의 수에 대한 시나리오 테스트를 StudyStatus 에 대한 유닛테스트로 추가했습니다

- 기존 Study 에 대한 edit 요청 로직에서 Study 내부의 changeStatus 를 사용하도록 하였었습니다. 해당 메소드 내부에서 스터디 상태 변경에 대한 제약을 검증하는 메소드를 요청합니다. 따라서 만약 기존의 Study 수정 api 를 통해 스터디 상태 변경 요청을 받는다면, 자동으로 스터디 상태 변경에 대한 제약을 검증하고 , 허용되지 않는 변경에 대해서 예외를 던집니다 



- resolves #168 
