### PR TITLE
♻️ refactor : API 문서화 및 enum 소문자로 받도록 구현

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImpl.java
@@ -87,7 +87,7 @@ public class StudyCommandServiceImpl implements StudyCommandService {
         );
         StudyMember studyMember = studyMemberRepository.findById(memberId)
             .orElseThrow(() -> new StudyJoinRequestNotFoundException(STUDY_JOIN_REQUEST_NOT_FOUND));
-        studyMember.changeStatus(StudyMemberStatus.valueOf(request.status()));
+        studyMember.changeStatus(StudyMemberStatus.valueOf(request.status().toUpperCase()));
     }
 
     @Override

--- a/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
@@ -534,6 +534,7 @@ class StudyApiTest extends IntegrationTest {
                     .responseSchema(Schema.schema("스터디 신청자목록 응답")),
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                tokenRequestHeader(),
                 pathParameters(
                     parameterWithName("studyId").description("스터디 아이디")
                 ),


### PR DESCRIPTION
## 작업사항
- 스터디 신청 목록에 OAuth Token을 받는다고 명시하도록 스웨거 문서 수정
- 스터디 신청 승락 및 거절 시 status 값으로 받는 값을 대소문자 구분하지 않고 처리하도록 구현(ACCEPTED, DENIED)

- resolves #189 
