### PR TITLE
♻️ refactor : 댓글 삭제 기능에 대한 validation 추가

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/facade/CommentFacade.java
@@ -7,6 +7,7 @@ import com.devcourse.checkmoi.domain.comment.service.CommentCommandService;
 import com.devcourse.checkmoi.domain.comment.service.CommentQueryService;
 import com.devcourse.checkmoi.domain.post.dto.PostResponse.PostInfo;
 import com.devcourse.checkmoi.domain.post.service.PostQueryService;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
 import com.devcourse.checkmoi.domain.study.service.StudyQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/devcourse/checkmoi/domain/comment/service/CommentCommandService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/service/CommentCommandService.java
@@ -2,6 +2,7 @@ package com.devcourse.checkmoi.domain.comment.service;
 
 import com.devcourse.checkmoi.domain.comment.dto.CommentRequest.Create;
 import com.devcourse.checkmoi.domain.comment.dto.CommentRequest.Edit;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
 
 public interface CommentCommandService {
 

--- a/src/main/java/com/devcourse/checkmoi/domain/comment/service/CommentCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/service/CommentCommandServiceImpl.java
@@ -7,6 +7,8 @@ import com.devcourse.checkmoi.domain.comment.exception.CommentNotFoundException;
 import com.devcourse.checkmoi.domain.comment.model.Comment;
 import com.devcourse.checkmoi.domain.comment.repository.CommentRepository;
 import com.devcourse.checkmoi.domain.comment.service.validator.CommentValidator;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
+import com.devcourse.checkmoi.domain.study.repository.StudyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,10 +24,14 @@ public class CommentCommandServiceImpl implements CommentCommandService {
 
     private final CommentValidator commentValidator;
 
+    private final StudyRepository studyRepository;
+
     @Override
     public void deleteById(Long userId, Long commentId) {
-        // TODO: validation 댓글을 작성한 본인과 스터디장만 삭제할 수 있다
-        // TODO: 스터디 종료상태인지 확인한다
+        Comment comment = commentRepository.findById(commentId)
+            .orElseThrow(CommentNotFoundException::new);
+        Long ownerId = studyRepository.findStudyOwner(comment.getPost().getStudy().getId());
+        commentValidator.deleteComment(comment, ownerId, userId);
         commentRepository.deleteById(commentId);
     }
 

--- a/src/main/java/com/devcourse/checkmoi/domain/comment/service/validator/CommentValidator.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/service/validator/CommentValidator.java
@@ -5,4 +5,6 @@ import com.devcourse.checkmoi.domain.comment.model.Comment;
 public interface CommentValidator {
 
     void editComment(Comment comment, Long userId);
+
+    void deleteComment(Comment comment, Long ownerId, Long userId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/comment/service/validator/CommentValidator.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/service/validator/CommentValidator.java
@@ -1,10 +1,6 @@
 package com.devcourse.checkmoi.domain.comment.service.validator;
 
-import com.devcourse.checkmoi.domain.comment.model.Comment;
-
 public interface CommentValidator {
 
-    void editComment(Comment comment, Long userId);
-
-    void deleteComment(Comment comment, Long ownerId, Long userId);
+    void commentPermission(Long userId, Long... compareId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/comment/service/validator/CommentValidatorImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/service/validator/CommentValidatorImpl.java
@@ -4,6 +4,7 @@ import com.devcourse.checkmoi.domain.comment.exception.CommentNoPermissionExcept
 import com.devcourse.checkmoi.domain.comment.model.Comment;
 import com.devcourse.checkmoi.domain.study.exception.FinishedStudyException;
 import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
 import com.devcourse.checkmoi.domain.user.model.User;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +16,19 @@ public class CommentValidatorImpl implements CommentValidator {
         Study study = comment.getPost().getStudy();
 
         if (!writer.getId().equals(userId)) {
+            throw new CommentNoPermissionException();
+        }
+        if (study.isFinished()) {
+            throw new FinishedStudyException();
+        }
+    }
+
+    @Override
+    public void deleteComment(Comment comment, Long ownerId, Long userId) {
+        User writer = comment.getUser();
+        Study study = comment.getPost().getStudy();
+
+        if (!(writer.getId().equals(userId) || ownerId.equals(userId))) {
             throw new CommentNoPermissionException();
         }
         if (study.isFinished()) {

--- a/src/main/java/com/devcourse/checkmoi/domain/comment/service/validator/CommentValidatorImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/service/validator/CommentValidatorImpl.java
@@ -2,37 +2,23 @@ package com.devcourse.checkmoi.domain.comment.service.validator;
 
 import com.devcourse.checkmoi.domain.comment.exception.CommentNoPermissionException;
 import com.devcourse.checkmoi.domain.comment.model.Comment;
-import com.devcourse.checkmoi.domain.study.exception.FinishedStudyException;
 import com.devcourse.checkmoi.domain.study.model.Study;
-import com.devcourse.checkmoi.domain.study.model.StudyMember;
-import com.devcourse.checkmoi.domain.user.model.User;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CommentValidatorImpl implements CommentValidator {
 
-    public void editComment(Comment comment, Long userId) {
-        User writer = comment.getUser();
-        Study study = comment.getPost().getStudy();
-
-        if (!writer.getId().equals(userId)) {
-            throw new CommentNoPermissionException();
-        }
-        if (study.isFinished()) {
-            throw new FinishedStudyException();
-        }
-    }
-
     @Override
-    public void deleteComment(Comment comment, Long ownerId, Long userId) {
-        User writer = comment.getUser();
-        Study study = comment.getPost().getStudy();
-
-        if (!(writer.getId().equals(userId) || ownerId.equals(userId))) {
-            throw new CommentNoPermissionException();
+    public void commentPermission(Long userId, Long... compareId) {
+        boolean permissionUser = false;
+        for (Long id : compareId) {
+            if (userId.equals(id)) {
+                permissionUser = true;
+                break ;
+            }
         }
-        if (study.isFinished()) {
-            throw new FinishedStudyException();
+        if (!permissionUser) {
+            throw new CommentNoPermissionException();
         }
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImpl.java
@@ -13,7 +13,7 @@ import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
 import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.devcourse.checkmoi.domain.study.repository.StudyMemberRepository;
 import com.devcourse.checkmoi.domain.study.repository.StudyRepository;
-import com.devcourse.checkmoi.domain.study.service.validator.StudyServiceValidator;
+import com.devcourse.checkmoi.domain.study.service.validator.StudyValidator;
 import com.devcourse.checkmoi.domain.user.exception.UserNotFoundException;
 import com.devcourse.checkmoi.domain.user.model.User;
 import com.devcourse.checkmoi.domain.user.repository.UserRepository;
@@ -34,7 +34,7 @@ public class StudyCommandServiceImpl implements StudyCommandService {
 
     private final UserRepository userRepository;
 
-    private final StudyServiceValidator studyValidator;
+    private final StudyValidator studyValidator;
 
     @Override
     public Long createStudy(Create request, Long userId) {

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyQueryServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyQueryServiceImpl.java
@@ -11,7 +11,7 @@ import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.devcourse.checkmoi.domain.study.repository.StudyMemberRepository;
 import com.devcourse.checkmoi.domain.study.repository.StudyRepository;
 import com.devcourse.checkmoi.domain.study.service.dto.ExpiredStudies;
-import com.devcourse.checkmoi.domain.study.service.validator.StudyServiceValidator;
+import com.devcourse.checkmoi.domain.study.service.validator.StudyValidator;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StudyQueryServiceImpl implements StudyQueryService {
 
-    private final StudyServiceValidator studyValidator;
+    private final StudyValidator studyValidator;
 
     private final StudyRepository studyRepository;
 

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/validator/StudyValidator.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/validator/StudyValidator.java
@@ -3,7 +3,7 @@ package com.devcourse.checkmoi.domain.study.service.validator;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyMember;
 
-public interface StudyServiceValidator {
+public interface StudyValidator {
 
     void validateExistStudy(boolean existStudy);
 

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/validator/StudyValidatorImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/validator/StudyValidatorImpl.java
@@ -13,7 +13,7 @@ import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
 import org.springframework.stereotype.Component;
 
 @Component
-public class StudyServiceValidatorImpl implements StudyServiceValidator {
+public class StudyValidatorImpl implements StudyValidator {
 
     @Override
     public void validateExistStudy(boolean existStudy) {

--- a/src/test/java/com/devcourse/checkmoi/domain/comment/api/CommentApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/comment/api/CommentApiTest.java
@@ -41,6 +41,7 @@ import com.devcourse.checkmoi.domain.comment.service.CommentCommandService;
 import com.devcourse.checkmoi.domain.comment.service.CommentQueryService;
 import com.devcourse.checkmoi.domain.post.model.Post;
 import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
 import com.devcourse.checkmoi.domain.token.dto.TokenResponse.TokenWithUserInfo;
 import com.devcourse.checkmoi.domain.user.model.User;
 import com.devcourse.checkmoi.template.IntegrationTest;

--- a/src/test/java/com/devcourse/checkmoi/domain/comment/facade/CommentFacadeTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/comment/facade/CommentFacadeTest.java
@@ -2,10 +2,18 @@ package com.devcourse.checkmoi.domain.comment.facade;
 
 import static com.devcourse.checkmoi.util.DTOGeneratorUtil.makeCommentInfo;
 import static com.devcourse.checkmoi.util.DTOGeneratorUtil.makePostInfo;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeBookWithId;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudyMember;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudyMemberWithId;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudyWithId;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeUserWithId;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import com.devcourse.checkmoi.domain.book.model.Book;
 import com.devcourse.checkmoi.domain.comment.dto.CommentRequest.Create;
 import com.devcourse.checkmoi.domain.comment.dto.CommentRequest.Search;
 import com.devcourse.checkmoi.domain.comment.dto.CommentResponse.Comments;
@@ -13,7 +21,12 @@ import com.devcourse.checkmoi.domain.comment.service.CommentCommandService;
 import com.devcourse.checkmoi.domain.comment.service.CommentQueryService;
 import com.devcourse.checkmoi.domain.post.dto.PostResponse.PostInfo;
 import com.devcourse.checkmoi.domain.post.service.PostQueryService;
+import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
+import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.devcourse.checkmoi.domain.study.service.StudyQueryService;
+import com.devcourse.checkmoi.domain.user.model.User;
 import com.devcourse.checkmoi.global.model.SimplePage;
 import java.util.List;
 import org.assertj.core.api.Assertions;
@@ -99,4 +112,6 @@ class CommentFacadeTest {
             Assertions.assertThat(want.totalPage()).isEqualTo(want.totalPage());
         }
     }
+
+
 }

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
@@ -33,7 +33,7 @@ import com.devcourse.checkmoi.domain.study.model.StudyMember;
 import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
 import com.devcourse.checkmoi.domain.study.repository.StudyMemberRepository;
 import com.devcourse.checkmoi.domain.study.repository.StudyRepository;
-import com.devcourse.checkmoi.domain.study.service.validator.StudyServiceValidator;
+import com.devcourse.checkmoi.domain.study.service.validator.StudyValidator;
 import com.devcourse.checkmoi.domain.user.exception.UserNotFoundException;
 import com.devcourse.checkmoi.domain.user.model.User;
 import com.devcourse.checkmoi.domain.user.repository.UserRepository;
@@ -67,7 +67,7 @@ class StudyCommandServiceImplTest {
     UserRepository userRepository;
 
     @Mock
-    StudyServiceValidator studyValidator;
+    StudyValidator studyValidator;
 
     @Nested
     @DisplayName("스터디 등록 #5")

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyQueryServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyQueryServiceImplTest.java
@@ -27,7 +27,7 @@ import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.devcourse.checkmoi.domain.study.repository.StudyMemberRepository;
 import com.devcourse.checkmoi.domain.study.repository.StudyRepository;
-import com.devcourse.checkmoi.domain.study.service.validator.StudyServiceValidator;
+import com.devcourse.checkmoi.domain.study.service.validator.StudyValidator;
 import com.devcourse.checkmoi.domain.user.model.User;
 import com.devcourse.checkmoi.global.model.SimplePage;
 import java.util.List;
@@ -58,7 +58,7 @@ class StudyQueryServiceImplTest {
     StudyRepository studyRepository;
 
     @Mock
-    StudyServiceValidator studyValidator;
+    StudyValidator studyValidator;
 
     @Mock
     StudyMemberRepository studyMemberRepository;

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/validator/StudyValidatorImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/validator/StudyValidatorImplTest.java
@@ -25,35 +25,35 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-class StudyServiceValidatorImplTest {
+class StudyValidatorImplTest {
 
-    StudyServiceValidator studyServiceValidator = new StudyServiceValidatorImpl();
+    StudyValidator studyValidator = new StudyValidatorImpl();
 
     @Test
     @DisplayName("해당하는 스터디가 존재하는지 검사")
     void validateExistStudy() {
-        studyServiceValidator.validateExistStudy(true);
+        studyValidator.validateExistStudy(true);
         assertThrows(StudyNotFoundException.class,
-            () -> studyServiceValidator.validateExistStudy(false));
+            () -> studyValidator.validateExistStudy(false));
     }
 
     @Test
     @DisplayName("해당하는 아이디는 스터디장의 아이디와 일치하는지 검사")
     void validateStudyOwner() {
-        studyServiceValidator.validateStudyOwner(1L, 1L, "message");
+        studyValidator.validateStudyOwner(1L, 1L, "message");
         assertThrows(NotStudyOwnerException.class,
-            () -> studyServiceValidator.validateStudyOwner(1L, 2L, "스터디장은 2L"));
+            () -> studyValidator.validateStudyOwner(1L, 2L, "스터디장은 2L"));
     }
 
     @Test
     @DisplayName("스터디에 중복해서 가입신청하는지 검사")
     void validateDuplicateStudyMemberRequest() {
         User user = makeUser();
-        studyServiceValidator.validateDuplicateStudyMemberRequest(
+        studyValidator.validateDuplicateStudyMemberRequest(
             makeStudyMember(makeStudy(makeBook(), RECRUITING), user, DENIED));
 
         assertThrows(DuplicateStudyJoinRequestException.class,
-            () -> studyServiceValidator.validateDuplicateStudyMemberRequest(
+            () -> studyValidator.validateDuplicateStudyMemberRequest(
                 makeStudyMember(makeStudy(makeBook(), RECRUITING), user, PENDING)));
     }
 
@@ -68,7 +68,7 @@ class StudyServiceValidatorImplTest {
             Study study = makeStudyWithId(book, FINISHED, 1L);
 
             assertThatExceptionOfType(FinishedStudyException.class)
-                .isThrownBy(() -> studyServiceValidator.ongoingStudy(study));
+                .isThrownBy(() -> studyValidator.ongoingStudy(study));
         }
     }
 
@@ -81,7 +81,7 @@ class StudyServiceValidatorImplTest {
         void participateUser() {
             Long notFoundMemberId = null;
             assertThatExceptionOfType(NotJoinedMemberException.class)
-                .isThrownBy(() -> studyServiceValidator.participateUser(notFoundMemberId));
+                .isThrownBy(() -> studyValidator.participateUser(notFoundMemberId));
         }
     }
 


### PR DESCRIPTION
## 작업사항

- 댓글 존재 여부 확인 기능 추가
- 댓글 삭제시 현재 댓글 작성자 또는 스터디장인지 확인하고 아니라면 예외발생하는 기능 추가
- 이미 끝난 스터디에서는 댓글을 삭제하지 못하도록 하는 기능 추가
- 이에따른 테스트 코드 추가

## 중점적으로 봐야할 부분
- 현재 스터디장인지 확인해야 하는 부분에 대해서 좋은 방법이 떠오르지 않습니다. 지금 studyRepository를 이용해서 이를 해결했는데 스터디에서 다른 레포지터리를 가져와서 사용하는 것을 최대한 피하고 싶은데 좋은 방법이 떠오르지 않습니다. 🤔 

- resolves #136 
