### PR TITLE
♻️ refactor : 스터디신청승인

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/comment/facade/CommentFacade.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/facade/CommentFacade.java
@@ -28,8 +28,8 @@ public class CommentFacade {
 
     public Long createComment(Long postId, Long userId, Create request) {
         PostInfo post = postQueryService.findByPostId(userId, postId);
-        studyQueryService.ongoingStudy(post.studyId());
-        studyQueryService.participateUser(post.studyId(), userId);
+        studyQueryService.validateOngoingStudy(post.studyId());
+        studyQueryService.validateParticipateUser(post.studyId(), userId);
 
         return commentCommandService.createComment(postId, userId, request);
     }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
@@ -1,18 +1,18 @@
 package com.devcourse.checkmoi.domain.study.api;
 
 import static com.devcourse.checkmoi.global.util.ApiUtil.generatedUri;
-import com.devcourse.checkmoi.global.model.SimplePage;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Audit;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Create;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Edit;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Search;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.MyStudies;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
-import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyAppliers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMembers;
 import com.devcourse.checkmoi.domain.study.facade.StudyUserFacade;
 import com.devcourse.checkmoi.domain.study.service.StudyCommandService;
 import com.devcourse.checkmoi.domain.study.service.StudyQueryService;
+import com.devcourse.checkmoi.global.model.SimplePage;
 import com.devcourse.checkmoi.global.model.SuccessResponse;
 import com.devcourse.checkmoi.global.security.jwt.JwtAuthentication;
 import javax.validation.Valid;
@@ -68,17 +68,16 @@ public class StudyApi {
             new SuccessResponse<>(studyCommandService.editStudyInfo(studyId, user.id(), request)));
     }
 
-    @PutMapping("/studies/{studyId}/members/{memberId}")
-    public ResponseEntity<Void> auditStudyParticipation(
-        @PathVariable Long studyId,
-        @PathVariable Long memberId,
-        @AuthenticationPrincipal JwtAuthentication user,
-        @Valid @RequestBody Audit request
+
+    @GetMapping("/studies/me")
+    public ResponseEntity<SuccessResponse<MyStudies>> getMyStudies(
+        @AuthenticationPrincipal JwtAuthentication user
     ) {
-        studyCommandService.auditStudyParticipation(studyId, memberId, user.id(), request);
-        return ResponseEntity
-            .noContent()
-            .build();
+        MyStudies response = studyUserFacade.getMyStudies(user.id());
+
+        return ResponseEntity.ok(
+            new SuccessResponse<>(response)
+        );
     }
 
     @GetMapping("/studies")
@@ -101,8 +100,10 @@ public class StudyApi {
             .body(new SuccessResponse<>(studyMemberId));
     }
 
+    /********************************* StudyMember  ****************************************/
+
     @GetMapping("/studies/{studyId}/members")
-    public ResponseEntity<SuccessResponse<StudyAppliers>> getStudyAppliers(
+    public ResponseEntity<SuccessResponse<StudyMembers>> getStudyAppliers(
         @PathVariable Long studyId,
         @AuthenticationPrincipal JwtAuthentication user
     ) {
@@ -110,15 +111,17 @@ public class StudyApi {
             .body(new SuccessResponse<>(studyQueryService.getStudyAppliers(user.id(), studyId)));
     }
 
-    @GetMapping("/studies/me")
-    public ResponseEntity<SuccessResponse<MyStudies>> getMyStudies(
-        @AuthenticationPrincipal JwtAuthentication user
+    @PutMapping("/studies/{studyId}/members/{memberId}")
+    public ResponseEntity<Void> auditStudyParticipation(
+        @PathVariable Long studyId,
+        @PathVariable Long memberId,
+        @AuthenticationPrincipal JwtAuthentication user,
+        @Valid @RequestBody Audit request
     ) {
-        MyStudies response = studyUserFacade.getMyStudies(user.id());
-
-        return ResponseEntity.ok(
-            new SuccessResponse<>(response)
-        );
+        studyCommandService.auditStudyParticipation(studyId, memberId, user.id(), request);
+        return ResponseEntity
+            .noContent()
+            .build();
     }
 
     /********************************* API v2  ****************************************/

--- a/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyResponse.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyResponse.java
@@ -2,11 +2,12 @@ package com.devcourse.checkmoi.domain.study.dto;
 
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.MyStudies;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
-import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyAppliers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyBookInfo;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetail;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMemberInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMembers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyUserInfo;
 import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfo;
@@ -19,7 +20,7 @@ import lombok.Builder;
 public sealed interface StudyResponse permits
     StudyInfo, StudyDetail, StudyDetailWithMembers,
     Studies, StudyBookInfo, StudyUserInfo,
-    StudyAppliers, MyStudies {
+    StudyMemberInfo, StudyMembers, MyStudies {
 
     record StudyInfo(
         Long id,
@@ -55,7 +56,7 @@ public sealed interface StudyResponse permits
     record StudyDetailWithMembers(
         StudyInfo study,
         StudyBookInfo book,
-        List<StudyUserInfo> members
+        List<StudyMemberInfo> members
     ) implements StudyResponse {
 
         @Builder
@@ -109,12 +110,22 @@ public sealed interface StudyResponse permits
         }
     }
 
-    record StudyAppliers(
-        List<StudyUserInfo> appliers
+    record StudyMembers(
+        List<StudyMemberInfo> members
     ) implements StudyResponse {
 
         @Builder
-        public StudyAppliers {
+        public StudyMembers {
+        }
+    }
+
+    record StudyMemberInfo(
+        Long id,
+        StudyUserInfo user
+    ) implements StudyResponse {
+
+        @Builder
+        public StudyMemberInfo {
         }
     }
 

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomRepositoryUtil.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomRepositoryUtil.java
@@ -1,0 +1,142 @@
+package com.devcourse.checkmoi.domain.study.repository;
+
+import static com.devcourse.checkmoi.domain.study.model.QStudy.study;
+import static com.devcourse.checkmoi.domain.study.model.QStudyMember.studyMember;
+import static com.devcourse.checkmoi.domain.study.model.StudyMemberStatus.ACCEPTED;
+import static com.devcourse.checkmoi.domain.study.model.StudyMemberStatus.OWNED;
+import static com.devcourse.checkmoi.domain.study.model.StudyStatus.FINISHED;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyBookInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetail;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMemberInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyUserInfo;
+import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import com.devcourse.checkmoi.domain.study.model.StudyStatus;
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomRepositoryUtil {
+
+    /******* Constructor  *******/
+
+    public static ConstructorExpression<StudyDetail> studyDetailConstructor() {
+        return Projections.constructor(StudyDetail.class,
+            studyInfoConstructor(),
+            studyBookInfoConstructor()
+        );
+    }
+
+    public static ConstructorExpression<StudyBookInfo> studyBookInfoConstructor() {
+        return Projections.constructor(
+            StudyBookInfo.class,
+            study.book.id,
+            study.book.title,
+            study.book.thumbnail,
+            study.book.author,
+            study.book.publisher,
+            study.book.publishedAt.publishedAt,
+            study.book.isbn,
+            study.book.description,
+            study.book.createdAt
+        );
+    }
+
+    public static ConstructorExpression<StudyMemberInfo> StudyMemberInfoConstructor() {
+        return Projections.constructor(
+            StudyMemberInfo.class,
+            studyMember.id,
+            studyUserInfoConstructor()
+        );
+    }
+
+    public static ConstructorExpression<StudyUserInfo> studyUserInfoConstructor() {
+        return Projections.constructor(
+            StudyUserInfo.class,
+            studyMember.user.id,
+            studyMember.user.name,
+            studyMember.user.email.value.as("email"),
+            studyMember.user.profileImgUrl,
+            studyMember.user.temperature
+        );
+    }
+
+    public static ConstructorExpression<StudyInfo> studyInfoConstructor() {
+        return Projections.constructor(
+            StudyInfo.class,
+            study.id, study.name, study.thumbnailUrl, study.description, study.status,
+            study.currentParticipant, study.maxParticipant, study.gatherStartDate,
+            study.gatherEndDate, study.studyStartDate, study.studyEndDate
+        );
+    }
+
+
+    /******* Expression *******/
+    public static BooleanExpression isStudyParticipant(boolean participant) {
+        return participant ?
+            studyMember.status.in(OWNED, ACCEPTED) :
+            studyMember.status.notIn(OWNED, ACCEPTED);
+    }
+
+    public static BooleanExpression isFinished(boolean finish) {
+        return finish ?
+            study.status.eq(FINISHED) :
+            study.status.notIn(FINISHED);
+    }
+
+    public static BooleanExpression eqStudyMemberStatus(StudyMemberStatus... statuses) {
+        if (statuses.length == 0) {
+            return null;
+        }
+        return studyMember.status.in(statuses);
+    }
+
+    public static BooleanExpression eqStudyMemberStatus(String status) {
+        if (status == null) {
+            return null;
+        }
+        return studyMember.status.eq(StudyMemberStatus.valueOf(status.toUpperCase()));
+    }
+
+    public static BooleanExpression eqStudyId(Long studyId) {
+        if (studyId == null) {
+            return null;
+        }
+        return studyMember.study.id.eq(studyId);
+    }
+
+    public static BooleanExpression eqUserId(Long userId) {
+        if (userId == null) {
+            return null;
+        }
+        return studyMember.user.id.eq(userId);
+    }
+
+    public static BooleanExpression eqStudyStatus(String status) {
+        if (status == null) {
+            return null;
+        }
+        return study.status.eq(StudyStatus.nameOf(status));
+    }
+
+    public static BooleanExpression eqBookId(Long bookId) {
+        if (bookId == null) {
+            return null;
+        }
+        return study.book.id.eq(bookId);
+    }
+
+    public static BooleanExpression isMember(Boolean condition) {
+        if (condition == null) {
+            return null;
+        }
+
+        if (condition.equals(Boolean.FALSE)) {
+            return studyMember.status.notIn(OWNED, ACCEPTED).or(study.status.eq(FINISHED));
+        }
+
+        return studyMember.status.in(OWNED, ACCEPTED).and(study.status.notIn(FINISHED));
+    }
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepository.java
@@ -2,9 +2,9 @@ package com.devcourse.checkmoi.domain.study.repository;
 
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Search;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
-import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyAppliers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMembers;
 import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.devcourse.checkmoi.domain.study.service.dto.ExpiredStudies;
 import java.time.LocalDate;
@@ -13,15 +13,12 @@ import org.springframework.data.domain.Pageable;
 
 public interface CustomStudyRepository {
 
-    Long findStudyOwner(Long studyId);
-
     Page<StudyInfo> findRecruitingStudyByBookId(Long bookId, Pageable pageable);
 
     StudyDetailWithMembers getStudyDetailWithMembers(Long studyId);
 
-    StudyAppliers getStudyApplicants(Long studyId);
+    StudyMembers getStudyApplicants(Long studyId);
 
-    void updateAllApplicantsAsDenied(Long studyId);
 
     Studies getParticipationStudies(Long userId);
 
@@ -29,9 +26,12 @@ public interface CustomStudyRepository {
 
     Studies getOwnedStudies(Long userId);
 
+
     Page<StudyInfo> findAllByCondition(Long userId, Search search, Pageable pageable);
 
-    ExpiredStudies getAllToBeProcessed(LocalDate current, StudyStatus toStatus);
+    ExpiredStudies getAllTobeProgressed(LocalDate current, StudyStatus toStatus);
 
     void updateStudyStatus(Long studyId, StudyStatus studyStatus);
+
+    void updateAllApplicantsAsDenied(Long studyId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepositoryImpl.java
@@ -4,22 +4,30 @@ import static com.devcourse.checkmoi.domain.study.model.QStudy.study;
 import static com.devcourse.checkmoi.domain.study.model.QStudyMember.studyMember;
 import static com.devcourse.checkmoi.domain.study.model.StudyMemberStatus.ACCEPTED;
 import static com.devcourse.checkmoi.domain.study.model.StudyMemberStatus.OWNED;
-import static com.devcourse.checkmoi.domain.study.model.StudyStatus.FINISHED;
+import static com.devcourse.checkmoi.domain.study.model.StudyMemberStatus.PENDING;
 import static com.devcourse.checkmoi.domain.study.model.StudyStatus.RECRUITING;
 import static com.devcourse.checkmoi.domain.study.model.StudyStatus.RECRUITING_FINISHED;
+import static com.devcourse.checkmoi.domain.study.repository.CustomRepositoryUtil.StudyMemberInfoConstructor;
+import static com.devcourse.checkmoi.domain.study.repository.CustomRepositoryUtil.eqBookId;
+import static com.devcourse.checkmoi.domain.study.repository.CustomRepositoryUtil.eqStudyId;
+import static com.devcourse.checkmoi.domain.study.repository.CustomRepositoryUtil.eqStudyMemberStatus;
+import static com.devcourse.checkmoi.domain.study.repository.CustomRepositoryUtil.eqStudyStatus;
+import static com.devcourse.checkmoi.domain.study.repository.CustomRepositoryUtil.eqUserId;
+import static com.devcourse.checkmoi.domain.study.repository.CustomRepositoryUtil.isFinished;
+import static com.devcourse.checkmoi.domain.study.repository.CustomRepositoryUtil.isMember;
+import static com.devcourse.checkmoi.domain.study.repository.CustomRepositoryUtil.isStudyParticipant;
+import static com.devcourse.checkmoi.domain.study.repository.CustomRepositoryUtil.studyDetailConstructor;
+import static com.devcourse.checkmoi.domain.study.repository.CustomRepositoryUtil.studyInfoConstructor;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Search;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
-import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyAppliers;
-import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyBookInfo;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetail;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
-import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyUserInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMemberInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMembers;
 import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
 import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.devcourse.checkmoi.domain.study.service.dto.ExpiredStudies;
-import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
@@ -37,21 +45,11 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
+
     @Override
     public Page<StudyInfo> findAllByCondition(Long userId, Search search, Pageable pageable) {
-        JPQLQuery<StudyInfo> query = jpaQueryFactory.select(
-                Projections.constructor(
-                    StudyInfo.class,
-                    study.id,
-                    study.name,
-                    study.thumbnailUrl,
-                    study.description,
-                    study.status,
-                    study.currentParticipant, study.maxParticipant,
-                    study.gatherStartDate, study.gatherEndDate,
-                    study.studyStartDate, study.studyEndDate
-                )
-            )
+        JPQLQuery<StudyInfo> query = jpaQueryFactory
+            .select(studyInfoConstructor())
             .from(study)
             .innerJoin(studyMember)
             .on(study.id.eq(studyMember.study.id))
@@ -64,39 +62,23 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
                 eqStudyStatus(search.studyStatus())
             )
             .groupBy(study.id);
-        long totalCount = query.fetchCount();
+
         List<StudyInfo> studies = query
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
-        return new PageImpl<>(studies, pageable, totalCount);
-    }
 
-    @Override
-    public Long findStudyOwner(Long studyId) {
-        return jpaQueryFactory.select(studyMember.user.id)
-            .from(studyMember)
-            .where(
-                study.id.eq(studyId),
-                studyMember.status.eq(StudyMemberStatus.OWNED)
-            )
-            .fetchOne();
+        return new PageImpl<>(studies, pageable, query.fetchCount());
     }
 
     @Override
     public Page<StudyInfo> findRecruitingStudyByBookId(Long bookId, Pageable pageable) {
-        JPQLQuery<StudyInfo> query = jpaQueryFactory.select(
-                Projections.constructor(
-                    StudyInfo.class,
-                    study.id, study.name, study.thumbnailUrl, study.description, study.status,
-                    study.currentParticipant, study.maxParticipant,
-                    study.gatherStartDate, study.gatherEndDate,
-                    study.studyStartDate, study.studyEndDate
-                ))
+        JPQLQuery<StudyInfo> query = jpaQueryFactory
+            .select(studyInfoConstructor())
             .from(study)
             .where(
-                study.book.id.eq(bookId),
-                study.status.eq(StudyStatus.RECRUITING)
+                eqBookId(bookId),
+                eqStudyStatus(RECRUITING.toString())
             );
 
         List<StudyInfo> studies = query
@@ -104,17 +86,13 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
             .limit(pageable.getPageSize())
             .fetch();
 
-        long totalCount = query.fetchCount();
-        return new PageImpl<>(studies, pageable, totalCount);
+        return new PageImpl<>(studies, pageable, query.fetchCount());
     }
 
     @Override
     public StudyDetailWithMembers getStudyDetailWithMembers(Long studyId) {
         StudyDetail studyDetail = getStudyDetailInfo(studyId);
-
-        List<StudyUserInfo> members =
-            getStudyMembers(studyId, ACCEPTED, StudyMemberStatus.OWNED);
-
+        List<StudyMemberInfo> members = getStudyMembers(studyId, ACCEPTED, OWNED);
         return StudyDetailWithMembers.builder()
             .study(studyDetail.study())
             .book(studyDetail.book())
@@ -123,44 +101,26 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
     }
 
     @Override
-    public StudyAppliers getStudyApplicants(Long studyId) {
-        List<StudyUserInfo> appliers = getStudyMembers(studyId, StudyMemberStatus.PENDING, null);
+    public StudyMembers getStudyApplicants(Long studyId) {
+        List<StudyMemberInfo> members = getStudyMembers(studyId, PENDING);
 
-        return StudyAppliers.builder()
-            .appliers(appliers)
+        return StudyMembers.builder()
+            .members(members)
             .build();
-    }
-
-    @Override
-    public void updateAllApplicantsAsDenied(Long studyId) {
-        jpaQueryFactory.update(studyMember)
-            .where(studyMember.study.id.eq(studyId),
-                studyMember.status.eq(StudyMemberStatus.PENDING))
-            .set(studyMember.status, StudyMemberStatus.DENIED)
-            .execute();
     }
 
     @Override
     public Studies getParticipationStudies(Long userId) {
         return new Studies(
-            jpaQueryFactory.select(
-                    Projections.constructor(
-                        StudyInfo.class,
-                        study.id, study.name, study.thumbnailUrl, study.description, study.status,
-                        study.currentParticipant, study.maxParticipant,
-                        study.gatherStartDate, study.gatherEndDate,
-                        study.studyStartDate, study.studyEndDate
-                    )
-                )
+            jpaQueryFactory
+                .select(studyInfoConstructor())
                 .from(study)
                 .innerJoin(studyMember)
                 .on(studyMember.study.id.eq(study.id))
                 .where(
-                    studyMember.user.id.eq(userId),
-                    studyMember.status.eq(ACCEPTED)
-                        .or(studyMember.status.eq(OWNED)),
-                    study.status.eq(StudyStatus.IN_PROGRESS)
-                        .or(study.status.eq(StudyStatus.RECRUITING))
+                    eqUserId(userId),
+                    isStudyParticipant(true),
+                    isFinished(false)
                 )
                 .fetch(), 0
         );
@@ -169,22 +129,15 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
     @Override
     public Studies getFinishedStudies(Long userId) {
         return new Studies(
-            jpaQueryFactory.select(
-                    Projections.constructor(
-                        StudyInfo.class,
-                        study.id, study.name, study.thumbnailUrl, study.description, study.status,
-                        study.currentParticipant, study.maxParticipant, study.gatherStartDate,
-                        study.gatherEndDate, study.studyStartDate, study.studyEndDate
-                    )
-                )
+            jpaQueryFactory
+                .select(studyInfoConstructor())
                 .from(study)
                 .innerJoin(studyMember)
                 .on(studyMember.study.id.eq(study.id))
                 .where(
-                    studyMember.user.id.eq(userId),
-                    studyMember.status.eq(ACCEPTED)
-                        .or(studyMember.status.eq(OWNED)),
-                    study.status.eq(FINISHED)
+                    eqUserId(userId),
+                    isStudyParticipant(true),
+                    isFinished(true)
                 )
                 .fetch(), 0
         );
@@ -193,33 +146,28 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
     @Override
     public Studies getOwnedStudies(Long userId) {
         return new Studies(
-            jpaQueryFactory.select(
-                    Projections.constructor(
-                        StudyInfo.class,
-                        study.id, study.name, study.thumbnailUrl, study.description, study.status,
-                        study.currentParticipant, study.maxParticipant, study.gatherStartDate,
-                        study.gatherEndDate, study.studyStartDate, study.studyEndDate
-                    )
-                )
+            jpaQueryFactory
+                .select(studyInfoConstructor())
                 .from(study)
                 .innerJoin(studyMember)
                 .on(studyMember.study.id.eq(study.id))
                 .where(
-                    studyMember.user.id.eq(userId),
-                    studyMember.status.eq(OWNED)
+                    eqUserId(userId),
+                    eqStudyMemberStatus(OWNED.toString())
                 )
                 .fetch(), 0
         );
     }
 
     @Override
-    public ExpiredStudies getAllToBeProcessed(LocalDate current, StudyStatus toStatus) {
+    public ExpiredStudies getAllTobeProgressed(LocalDate current, StudyStatus toStatus) {
         return switch (toStatus) {
             case IN_PROGRESS -> findAllToBeProgressed(current);
             default -> new ExpiredStudies(Collections.emptyList());
         };
     }
 
+    /***** update ********/
     @Override
     public void updateStudyStatus(Long studyId, StudyStatus studyStatus) {
         jpaQueryFactory.update(study)
@@ -228,14 +176,23 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
             .execute();
     }
 
+    @Override
+    public void updateAllApplicantsAsDenied(Long studyId) {
+        jpaQueryFactory
+            .update(studyMember)
+            .where(
+                studyMember.study.id.eq(studyId),
+                eqStudyMemberStatus(PENDING)
+            )
+            .set(studyMember.status, StudyMemberStatus.DENIED)
+            .execute();
+    }
+
     private ExpiredStudies findAllToBeProgressed(LocalDate current) {
         return new ExpiredStudies(
-            jpaQueryFactory.select(
-                    Projections.constructor(
-                        Long.class,
-                        study.id
-                    )
-                ).from(study)
+            jpaQueryFactory
+                .select(study.id)
+                .from(study)
                 .where(
                     study.studyStartDate.between(null, current),
                     study.status.eq(RECRUITING)
@@ -244,111 +201,31 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
         );
     }
 
+    /****** helper *******/
 
     private StudyDetail getStudyDetailInfo(Long studyId) {
-        return jpaQueryFactory.select(
-                Projections.constructor(StudyDetail.class,
-                    Projections.constructor(StudyInfo.class,
-                        study.id,
-                        study.name,
-                        study.thumbnailUrl,
-                        study.description,
-                        study.status,
-                        study.currentParticipant, study.maxParticipant,
-                        study.gatherStartDate, study.gatherEndDate,
-                        study.studyStartDate, study.studyEndDate
-                    ),
-                    Projections.constructor(StudyBookInfo.class,
-                        study.book.id,
-                        study.book.title,
-                        study.book.thumbnail,
-                        study.book.author,
-                        study.book.publisher,
-                        study.book.publishedAt.publishedAt,
-                        study.book.isbn,
-                        study.book.description,
-                        study.book.createdAt
-                    )
-                ))
+        return jpaQueryFactory
+            .select(studyDetailConstructor())
             .from(study)
             .innerJoin(study.book)
             .where(study.id.eq(studyId))
             .fetchOne();
     }
 
-    private List<StudyUserInfo> getStudyMembers(
-        Long studyId, StudyMemberStatus requiredStatus, StudyMemberStatus optionalStatus) {
-        return jpaQueryFactory.select(
-                Projections.constructor(
-                    StudyUserInfo.class,
-                    studyMember.user.id,
-                    studyMember.user.name,
-                    studyMember.user.email.value.as("email"),
-                    studyMember.user.profileImgUrl,
-                    studyMember.user.temperature
-                )
-            )
+    private List<StudyMemberInfo> getStudyMembers(
+        Long studyId, StudyMemberStatus... memberStatuses
+    ) {
+        return jpaQueryFactory
+            .select(StudyMemberInfoConstructor())
             .from(studyMember)
             .innerJoin(studyMember.user)
             .where(
                 eqStudyId(studyId),
-                eqStudyMemberStatus(requiredStatus)
-                    .or(eqStudyMemberStatus(optionalStatus)))
+                eqStudyMemberStatus(memberStatuses)
+            )
             .orderBy(studyMember.createdAt.asc())
             .fetch();
     }
 
-    private BooleanExpression eqStudyMemberStatus(StudyMemberStatus status) {
-        if (status == null) {
-            return null;
-        }
-        return studyMember.status.eq(status);
-    }
 
-    private BooleanExpression eqStudyMemberStatus(String status) {
-        if (status == null) {
-            return null;
-        }
-        return studyMember.status.eq(StudyMemberStatus.valueOf(status.toUpperCase()));
-    }
-
-    private BooleanExpression eqStudyId(Long studyId) {
-        if (studyId == null) {
-            return null;
-        }
-        return studyMember.study.id.eq(studyId);
-    }
-
-    private BooleanExpression eqUserId(Long userId) {
-        if (userId == null) {
-            return null;
-        }
-        return studyMember.user.id.eq(userId);
-    }
-
-    private BooleanExpression eqStudyStatus(String status) {
-        if (status == null) {
-            return null;
-        }
-        return study.status.eq(StudyStatus.nameOf(status));
-    }
-
-    private BooleanExpression eqBookId(Long bookId) {
-        if (bookId == null) {
-            return null;
-        }
-        return study.book.id.eq(bookId);
-    }
-
-    private BooleanExpression isMember(Boolean condition) {
-        if (condition == null) {
-            return null;
-        }
-
-        if (condition.equals(Boolean.FALSE)) {
-            return studyMember.status.notIn(OWNED, ACCEPTED).or(study.status.eq(FINISHED));
-        }
-
-        return studyMember.status.in(OWNED, ACCEPTED).and(study.status.notIn(FINISHED));
-    }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/StudyRepository.java
@@ -2,8 +2,12 @@ package com.devcourse.checkmoi.domain.study.repository;
 
 import com.devcourse.checkmoi.domain.study.model.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 
 public interface StudyRepository extends JpaRepository<Study, Long>, CustomStudyRepository {
 
+    @Query("select sm.user.id from StudyMember sm "
+        + "where sm.study.id = :studyId and sm.status = 'OWNED'")
+    Long findStudyOwner(Long studyId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyQueryService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyQueryService.java
@@ -2,8 +2,8 @@ package com.devcourse.checkmoi.domain.study.service;
 
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Search;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
-import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyAppliers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMembers;
 import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.devcourse.checkmoi.domain.study.service.dto.ExpiredStudies;
 import java.time.LocalDate;
@@ -15,7 +15,7 @@ public interface StudyQueryService {
 
     StudyDetailWithMembers getStudyInfoWithMembers(Long studyId);
 
-    StudyAppliers getStudyAppliers(Long userId, Long studyId);
+    StudyMembers getStudyAppliers(Long userId, Long studyId);
 
     Studies getParticipationStudies(Long userId);
 
@@ -23,9 +23,9 @@ public interface StudyQueryService {
 
     Studies getOwnedStudies(Long userId);
 
-    void ongoingStudy(Long studyId);
+    void validateOngoingStudy(Long studyId);
 
-    void participateUser(Long studyId, Long userId);
+    void validateParticipateUser(Long studyId, Long userId);
 
     Studies findAllByCondition(Long userId, Search search, Pageable pageable);
 

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyQueryServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyQueryServiceImpl.java
@@ -2,9 +2,9 @@ package com.devcourse.checkmoi.domain.study.service;
 
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Search;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
-import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyAppliers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMembers;
 import com.devcourse.checkmoi.domain.study.exception.StudyNotFoundException;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyStatus;
@@ -33,8 +33,8 @@ public class StudyQueryServiceImpl implements StudyQueryService {
 
     @Override
     public Studies findAllByCondition(Long userId, Search search, Pageable pageable) {
-        Page<StudyInfo> studyInfos = studyRepository.findAllByCondition(userId, search,
-            pageable);
+        Page<StudyInfo> studyInfos =
+            studyRepository.findAllByCondition(userId, search, pageable);
         return new Studies(
             studyInfos.getContent(),
             studyInfos.getTotalPages()
@@ -56,7 +56,7 @@ public class StudyQueryServiceImpl implements StudyQueryService {
     }
 
     @Override
-    public StudyAppliers getStudyAppliers(Long userId, Long studyId) {
+    public StudyMembers getStudyAppliers(Long userId, Long studyId) {
         Long studyOwnerId = studyRepository.findStudyOwner(studyId);
 
         studyValidator.validateStudyOwner(userId, studyOwnerId,
@@ -82,21 +82,24 @@ public class StudyQueryServiceImpl implements StudyQueryService {
         return studyRepository.getOwnedStudies(userId);
     }
 
-    @Override
-    public void ongoingStudy(Long studyId) {
-        Study study = studyRepository.findById(studyId)
-            .orElseThrow(StudyNotFoundException::new);
-        studyValidator.ongoingStudy(study);
-    }
-
-    @Override
-    public void participateUser(Long studyId, Long userId) {
-        studyValidator.participateUser(
-            studyMemberRepository.participateUserInStudy(studyId, userId));
-    }
 
     @Override
     public ExpiredStudies getAllExpiredStudies(LocalDate criteriaTime, StudyStatus toStatus) {
-        return studyRepository.getAllToBeProcessed(criteriaTime, toStatus);
+        return studyRepository.getAllTobeProgressed(criteriaTime, toStatus);
     }
+
+    /******************* Validate *******************/
+    @Override
+    public void validateOngoingStudy(Long studyId) {
+        Study study = studyRepository.findById(studyId)
+            .orElseThrow(StudyNotFoundException::new);
+        studyValidator.validateOngoingStudy(study);
+    }
+
+    @Override
+    public void validateParticipateUser(Long studyId, Long userId) {
+        studyValidator.validateParticipateUser(
+            studyMemberRepository.participateUserInStudy(studyId, userId));
+    }
+
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/validator/StudyServiceValidator.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/validator/StudyServiceValidator.java
@@ -11,7 +11,7 @@ public interface StudyServiceValidator {
 
     void validateDuplicateStudyMemberRequest(StudyMember studyMember);
 
-    void ongoingStudy(Study study);
+    void validateOngoingStudy(Study study);
 
-    void participateUser(Long memberId);
+    void validateParticipateUser(Long memberId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/validator/StudyServiceValidatorImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/validator/StudyServiceValidatorImpl.java
@@ -37,14 +37,14 @@ public class StudyServiceValidatorImpl implements StudyServiceValidator {
     }
 
     @Override
-    public void ongoingStudy(Study study) {
+    public void validateOngoingStudy(Study study) {
         if (study.isFinished()) {
             throw new FinishedStudyException();
         }
     }
 
     @Override
-    public void participateUser(Long memberId) {
+    public void validateParticipateUser(Long memberId) {
         if (memberId == null) {
             throw new NotJoinedMemberException();
         }

--- a/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
@@ -32,10 +32,11 @@ import com.devcourse.checkmoi.domain.study.dto.StudyRequest;
 import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Search;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.MyStudies;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
-import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyAppliers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyBookInfo;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyDetailWithMembers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMemberInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMembers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyUserInfo;
 import com.devcourse.checkmoi.domain.study.facade.StudyUserFacade;
 import com.devcourse.checkmoi.domain.study.model.Study;
@@ -241,7 +242,7 @@ class StudyApiTest extends IntegrationTest {
         private RestDocumentationResultHandler documentation() {
             return MockMvcRestDocumentationWrapper.document("study-audit",
                 ResourceSnippetParameters.builder()
-                    .tag("Study API")
+                    .tag("Study Member API")
                     .summary("스터디 가입 승낙 및 거절")
                     .description("스터디 가입 승낙 및 거절에 사용되는 API입니다.")
                     .requestSchema(Schema.schema("스터디 가입 승낙 및 거절 요청")),
@@ -370,7 +371,7 @@ class StudyApiTest extends IntegrationTest {
         private RestDocumentationResultHandler documentation() {
             return MockMvcRestDocumentationWrapper.document("study-join-request",
                 ResourceSnippetParameters.builder()
-                    .tag("Study API")
+                    .tag("Study Member API")
                     .summary("스터디 가입 신청")
                     .description("스터디 가입 신청에 사용되는 API입니다.")
                     .responseSchema(Schema.schema("스터디 가입 요청 응답")),
@@ -399,7 +400,18 @@ class StudyApiTest extends IntegrationTest {
             StudyDetailWithMembers expected = StudyDetailWithMembers.builder()
                 .study(givenStudyInfo())
                 .book(givenStudyBookInfo())
-                .members(List.of(givenUserInfo(), givenUserInfo()))
+                .members(
+                    List.of(
+                        StudyMemberInfo.builder()
+                            .id(1L)
+                            .user(givenUserInfo())
+                            .build(),
+                        StudyMemberInfo.builder()
+                            .id(2L)
+                            .user(givenUserInfo())
+                            .build()
+                    )
+                )
                 .build();
 
             given(studyQueryService.getStudyInfoWithMembers(anyLong())).willReturn(expected);
@@ -452,14 +464,18 @@ class StudyApiTest extends IntegrationTest {
                     // study member info
                     fieldWithPath("data.members[].id").
                         description("스터디 멤버 아이디"),
-                    fieldWithPath("data.members[].name")
-                        .description("스터디 멤버 이름"),
-                    fieldWithPath("data.members[].email")
-                        .description("스터디 멤버 이메일"),
-                    fieldWithPath("data.members[].temperature")
-                        .description("스터디 멤버 온도"),
-                    fieldWithPath("data.members[].image")
-                        .description("스터디 멤버 이미지 URL")
+
+                    // study member user info
+                    fieldWithPath("data.members[].user.id").
+                        description("스터디 멤버 유저 아이디"),
+                    fieldWithPath("data.members[].user.name")
+                        .description("스터디 멤버 유저 이름"),
+                    fieldWithPath("data.members[].user.email")
+                        .description("스터디 멤버 유저 이메일"),
+                    fieldWithPath("data.members[].user.temperature")
+                        .description("스터디 멤버 유저 온도"),
+                    fieldWithPath("data.members[].user.image")
+                        .description("스터디 멤버 유저 이미지 URL")
                 ));
         }
 
@@ -514,9 +530,17 @@ class StudyApiTest extends IntegrationTest {
 
             Long studyId = 1L;
 
+            var studyMember1 = StudyMemberInfo.builder()
+                .id(1L)
+                .user(userInfoList().get(0))
+                .build();
+            var studyMember2 = StudyMemberInfo.builder()
+                .id(2L)
+                .user(userInfoList().get(1))
+                .build();
+
             given(studyQueryService.getStudyAppliers(anyLong(), anyLong()))
-                .willReturn(
-                    new StudyAppliers(userInfoList()));
+                .willReturn(new StudyMembers(List.of(studyMember1, studyMember2)));
 
             mockMvc.perform(get("/api/studies/{studyId}/members", studyId)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + givenUser.accessToken()))
@@ -527,7 +551,7 @@ class StudyApiTest extends IntegrationTest {
         private RestDocumentationResultHandler documentation() {
             return MockMvcRestDocumentationWrapper.document("study-join-request-list",
                 ResourceSnippetParameters.builder()
-                    .tag("Study API")
+                    .tag("Study Member API")
                     .summary("스터디 신청자 목록 조회 API")
                     .description("해당하는 스터디에 대해 아직 처리되지 않은 신청자 목록을 가져옵니다")
                     .requestSchema(Schema.schema("스터디 신청자 목록 요청"))
@@ -535,25 +559,28 @@ class StudyApiTest extends IntegrationTest {
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 tokenRequestHeader(),
+
                 pathParameters(
                     parameterWithName("studyId").description("스터디 아이디")
                 ),
                 responseFields(
-                    fieldWithPath("data.appliers[].id").
-                        description("스터디 신청 멤버 아이디"),
-                    fieldWithPath("data.appliers[].name")
-                        .description("스터디 신청 멤버 이름"),
-                    fieldWithPath("data.appliers[].email")
-                        .description("스터디 신청 멤버 이메일"),
-                    fieldWithPath("data.appliers[].temperature")
-                        .description("스터디 신청 멤버 온도"),
-                    fieldWithPath("data.appliers[].image")
-                        .description("스터디 신청 멤버 이미지 URL")
+                    fieldWithPath("data.members[].id").
+                        description("스터디 멤버 아이디"),
+
+                    fieldWithPath("data.members[].user.id")
+                        .description("스터디 멤버 유저 아이디"),
+                    fieldWithPath("data.members[].user.name")
+                        .description("스터디 멤버 유저 이름"),
+                    fieldWithPath("data.members[].user.email")
+                        .description("스터디 멤버 유저 이메일"),
+                    fieldWithPath("data.members[].user.temperature")
+                        .description("스터디 멤버 유저 온도"),
+                    fieldWithPath("data.members[].user.image")
+                        .description("스터디 멤버 유저 이미지 URL")
                 ));
         }
 
         private List<StudyUserInfo> userInfoList() {
-
             return LongStream.range(1, 3).mapToObj(this::createUserInfo).toList();
         }
 

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyQueryServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyQueryServiceImplTest.java
@@ -17,8 +17,9 @@ import static org.mockito.Mockito.times;
 import com.devcourse.checkmoi.domain.book.model.Book;
 import com.devcourse.checkmoi.domain.study.converter.StudyConverter;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
-import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyAppliers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMemberInfo;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMembers;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyUserInfo;
 import com.devcourse.checkmoi.domain.study.exception.FinishedStudyException;
 import com.devcourse.checkmoi.domain.study.exception.NotJoinedMemberException;
@@ -32,6 +33,7 @@ import com.devcourse.checkmoi.domain.user.model.User;
 import com.devcourse.checkmoi.global.model.SimplePage;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -97,13 +99,13 @@ class StudyQueryServiceImplTest {
 
     @Nested
     @DisplayName("스터디 신청 내역 조회")
-    class GetStudyAppliersTest {
+    class GetStudyMembersTest {
 
         private Long studyLeaderId = 1L;
 
         private Long studyId = 1L;
 
-        private StudyAppliers expectedAppliers = createAppliersData();
+        private StudyMembers expectedAppliers = createAppliersData();
 
 
         @Test
@@ -121,7 +123,7 @@ class StudyQueryServiceImplTest {
                 .when(studyValidator)
                 .validateStudyOwner(anyLong(), anyLong(), anyString());
 
-            StudyAppliers returnedAppliers = studyQueryService.getStudyAppliers(userId, studyId);
+            StudyMembers returnedAppliers = studyQueryService.getStudyAppliers(userId, studyId);
 
             Assertions.assertThat(returnedAppliers)
                 .usingRecursiveComparison()
@@ -145,34 +147,42 @@ class StudyQueryServiceImplTest {
             ).isInstanceOf(NotStudyOwnerException.class);
         }
 
-        private StudyAppliers createAppliersData() {
+        private StudyMembers createAppliersData() {
+            List<StudyUserInfo> users = List.of(
+                makeStudyUserInfoWithId(1L),
+                makeStudyUserInfoWithId(2L),
+                makeStudyUserInfoWithId(3L)
+            );
 
-            return StudyAppliers.builder()
-                .appliers(
+            return StudyMembers.builder()
+                .members(
                     List.of(
-                        StudyUserInfo.builder()
+                        StudyMemberInfo.builder()
                             .id(1L)
-                            .email("abc@naver.com")
-                            .name("abc")
-                            .image("https://south/dev/abc.png")
-                            .temperature(36.5f)
+                            .user(makeStudyUserInfoWithId(1L))
                             .build(),
-                        StudyUserInfo.builder()
-                            .id(2L)
-                            .email("abcd@naver.com")
-                            .name("abcd")
-                            .image("https://south/dev/abcd.png")
-                            .temperature(36.5f)
+                        StudyMemberInfo.builder()
+                            .id(1L)
+                            .user(makeStudyUserInfoWithId(1L))
                             .build(),
-                        StudyUserInfo.builder()
-                            .id(3L)
-                            .email("abce@naver.com")
-                            .name("abce")
-                            .image("https://south/dev/abce.png")
-                            .temperature(36.5f)
+                        StudyMemberInfo.builder()
+                            .id(1L)
+                            .user(makeStudyUserInfoWithId(1L))
                             .build()
                     )
-                ).build();
+                )
+                .build();
+        }
+
+        private StudyUserInfo makeStudyUserInfoWithId(Long id) {
+            String email = UUID.randomUUID().toString().substring(20);
+            return StudyUserInfo.builder()
+                .id(id)
+                .email(email + "@naver.com")
+                .name("abc")
+                .image("https://south/dev/abc.png")
+                .temperature(36.5f)
+                .build();
         }
     }
 
@@ -263,11 +273,11 @@ class StudyQueryServiceImplTest {
             given(studyRepository.findById(anyLong()))
                 .willReturn(Optional.of(study));
 
-            studyQueryService.ongoingStudy(study.getId());
+            studyQueryService.validateOngoingStudy(study.getId());
 
             then(studyValidator)
                 .should(times(1))
-                .ongoingStudy(any(Study.class));
+                .validateOngoingStudy(any(Study.class));
         }
 
         @Test
@@ -278,10 +288,10 @@ class StudyQueryServiceImplTest {
             given(studyRepository.findById(anyLong()))
                 .willReturn(Optional.of(finishedStudy));
             doThrow(FinishedStudyException.class)
-                .when(studyValidator).ongoingStudy(finishedStudy);
+                .when(studyValidator).validateOngoingStudy(finishedStudy);
 
             assertThatExceptionOfType(FinishedStudyException.class)
-                .isThrownBy(() -> studyQueryService.ongoingStudy(finishedStudy.getId()));
+                .isThrownBy(() -> studyQueryService.validateOngoingStudy(finishedStudy.getId()));
         }
     }
 
@@ -303,11 +313,11 @@ class StudyQueryServiceImplTest {
             given(studyMemberRepository.participateUserInStudy(anyLong(), anyLong()))
                 .willReturn(memberId);
 
-            studyQueryService.participateUser(study.getId(), user.getId());
+            studyQueryService.validateParticipateUser(study.getId(), user.getId());
 
             then(studyValidator)
                 .should(times(1))
-                .participateUser(anyLong());
+                .validateParticipateUser(anyLong());
         }
 
         @Test
@@ -319,10 +329,11 @@ class StudyQueryServiceImplTest {
             given(studyMemberRepository.participateUserInStudy(anyLong(), anyLong()))
                 .willReturn(notFoundMemberId);
             doThrow(NotJoinedMemberException.class)
-                .when(studyValidator).participateUser(notFoundMemberId);
+                .when(studyValidator).validateParticipateUser(notFoundMemberId);
 
             assertThatExceptionOfType(NotJoinedMemberException.class)
-                .isThrownBy(() -> studyQueryService.participateUser(study.getId(), otherUserId));
+                .isThrownBy(
+                    () -> studyQueryService.validateParticipateUser(study.getId(), otherUserId));
         }
     }
 }

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/validator/StudyServiceValidatorImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/validator/StudyServiceValidatorImplTest.java
@@ -68,7 +68,7 @@ class StudyServiceValidatorImplTest {
             Study study = makeStudyWithId(book, FINISHED, 1L);
 
             assertThatExceptionOfType(FinishedStudyException.class)
-                .isThrownBy(() -> studyServiceValidator.ongoingStudy(study));
+                .isThrownBy(() -> studyServiceValidator.validateOngoingStudy(study));
         }
     }
 
@@ -81,7 +81,7 @@ class StudyServiceValidatorImplTest {
         void participateUser() {
             Long notFoundMemberId = null;
             assertThatExceptionOfType(NotJoinedMemberException.class)
-                .isThrownBy(() -> studyServiceValidator.participateUser(notFoundMemberId));
+                .isThrownBy(() -> studyServiceValidator.validateParticipateUser(notFoundMemberId));
         }
     }
 


### PR DESCRIPTION
## 작업사항
- Study 쪽 QueryDsl 관련 공통 부분 메서드를 CustomRepositoryUtil로 묶었습니다
분리를 함에따라 CustomStudyRepository 355 line -> 232 line 으로 줄어들었습니다
![image](https://user-images.githubusercontent.com/41179265/184299013-2d0d3bcd-cb38-436f-9398-a0d371637871.png)

- Study와 StudyMember 부분을 좀 더 명확히 구분하였습니다
![image](https://user-images.githubusercontent.com/41179265/184298859-1e991c5b-1f23-4ccb-8784-b82d9945a9b2.png)
![image](https://user-images.githubusercontent.com/41179265/184298877-b4848da9-7cc1-47e7-856a-60edb49b9028.png)

- validation 하는 메서드의 이름을 check, validate 의 접두사로 통일하였습니다
- 유저 정보만을 반환하던 StudyAppliers에서 멤버 정보를 반환하는 StudyMemberInfo로 변경하였습니다
추가적으로 기존에 반환하던 값을 user로 묶고 member에 포함되어있는 id값을 추가하였습니다.
![image](https://user-images.githubusercontent.com/41179265/184299153-e4aed018-e91a-4d86-bc0a-7c1162075892.png)

- CustomRepository가 거대해지고 있다고 느껴져 findStudyOwner와 같은 간단한 쿼리를 JPQL로 변경하였습니다
![image](https://user-images.githubusercontent.com/41179265/184299282-ddb9708e-98fa-4d5f-9a73-8e69449d2c11.png)


## 중점적으로 봐야할 부분

- resolves #193 
