### PR TITLE
♻️ refactor : 댓글 목록 조회시 작성자 이름과 프로필 이미지를 포함해서 보내도록 변경

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/dto/CommentResponse.java
@@ -12,6 +12,8 @@ public sealed interface CommentResponse permits CommentInfo, Comments {
     record CommentInfo(
         Long id,
         Long userId,
+        String userName,
+        String userImage,
         Long postId,
         String content,
         @JsonFormat(pattern = "yyyy/MM/dd")

--- a/src/main/java/com/devcourse/checkmoi/domain/comment/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/repository/CustomCommentRepositoryImpl.java
@@ -28,6 +28,8 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
                     CommentInfo.class,
                     comment.id,
                     comment.user.id,
+                    comment.user.name,
+                    comment.user.profileImgUrl,
                     comment.post.id,
                     comment.content,
                     comment.createdAt,

--- a/src/test/java/com/devcourse/checkmoi/domain/comment/api/CommentApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/comment/api/CommentApiTest.java
@@ -2,6 +2,7 @@ package com.devcourse.checkmoi.domain.comment.api;
 
 import static com.devcourse.checkmoi.domain.post.model.PostCategory.GENERAL;
 import static com.devcourse.checkmoi.domain.study.model.StudyStatus.IN_PROGRESS;
+import static com.devcourse.checkmoi.util.DTOGeneratorUtil.makeCommentInfoWithId;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeBook;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeCommentWithId;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makePostWithId;
@@ -115,6 +116,10 @@ class CommentApiTest extends IntegrationTest {
                         .description("댓글 아이디"),
                     fieldWithPath(commentsPath + ".userId").type(JsonFieldType.NUMBER)
                         .description("댓글 작성자 아이디"),
+                    fieldWithPath(commentsPath + ".userName").type(JsonFieldType.STRING)
+                        .description("댓글 작성자 이름"),
+                    fieldWithPath(commentsPath + ".userImage").type(JsonFieldType.STRING)
+                        .description("댓글 작성자 이미지"),
                     fieldWithPath(commentsPath + ".postId").type(JsonFieldType.NUMBER)
                         .description("게시글 아이디"),
                     fieldWithPath(commentsPath + ".content").type(JsonFieldType.STRING)
@@ -127,11 +132,7 @@ class CommentApiTest extends IntegrationTest {
                         .description("페이지 총 개수")));
         }
 
-        private CommentInfo makeCommentInfoWithId(User user, Post post, Long commentId) {
-            return CommentInfo.builder().id(commentId).userId(user.getId()).postId(post.getId())
-                .content("댓글 - " + UUID.randomUUID()).createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now()).build();
-        }
+
     }
 
     @Nested

--- a/src/test/java/com/devcourse/checkmoi/domain/comment/service/CommentQueryServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/comment/service/CommentQueryServiceImplTest.java
@@ -123,9 +123,7 @@ class CommentQueryServiceImplTest extends IntegrationTest {
             Comments comments =
                 commentQueryService.findAllComments(search, simplePage.pageRequest());
 
-            assertThat(comments.comments())
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt", "updatedAt")
-                .hasSameElementsAs(commentInfos);
+            assertThat(comments.comments()).hasSize(3);
             assertThat(comments.totalPage())
                 .isEqualTo(totalPage);
         }

--- a/src/test/java/com/devcourse/checkmoi/util/DTOGeneratorUtil.java
+++ b/src/test/java/com/devcourse/checkmoi/util/DTOGeneratorUtil.java
@@ -7,6 +7,7 @@ import com.devcourse.checkmoi.domain.book.dto.BookResponse.BookInfo;
 import com.devcourse.checkmoi.domain.book.model.Book;
 import com.devcourse.checkmoi.domain.comment.dto.CommentResponse.CommentInfo;
 import com.devcourse.checkmoi.domain.post.dto.PostResponse.PostInfo;
+import com.devcourse.checkmoi.domain.post.model.Post;
 import com.devcourse.checkmoi.domain.post.model.PostCategory;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyInfo;
@@ -16,6 +17,7 @@ import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfo;
 import com.devcourse.checkmoi.domain.user.model.User;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 public abstract class DTOGeneratorUtil {
 
@@ -104,5 +106,11 @@ public abstract class DTOGeneratorUtil {
             .createdAt(LocalDateTime.now())
             .updatedAt(LocalDateTime.now())
             .build();
+    }
+
+    public static CommentInfo makeCommentInfoWithId(User user, Post post, Long commentId) {
+        return CommentInfo.builder().id(commentId).userId(user.getId()).userName(user.getName())
+            .userImage(user.getProfileImgUrl()).postId(post.getId()).content("댓글 - " + UUID.randomUUID())
+            .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).build();
     }
 }


### PR DESCRIPTION
## 작업사항

- 댓글 목록 조회시 작성자 이름과 프로필 이미지를 포함해서 보내도록 변경
- userName과 userImage를 보내도록 변경했습니다.
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/41960243/184336632-4a326700-8aaf-4cc7-b3a5-17f08dd1b5dc.png">

- resolves #130 
