### PR TITLE
✨ feat : 특정한 문자열을 입출력하는 열거타입 정의 (#202)

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/book/dto/BookRequest.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/book/dto/BookRequest.java
@@ -17,7 +17,7 @@ public sealed interface BookRequest permits CreateBook, Search {
         // 검색조건
         @Nullable Long bookId,
         @Nullable Long studyId,
-        @ValueOfEnum(enumClass = StudyStatus.class)
+        @ValueOfEnum(codeMappingEnumClass = StudyStatus.class)
         @Nullable String studyStatus,
 
         // 정렬조건

--- a/src/main/java/com/devcourse/checkmoi/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/dto/PostRequest.java
@@ -13,7 +13,7 @@ public sealed interface PostRequest permits Search, Create, Edit {
 
     record Search(
         @NotNull(message = "게시글을 조회하려는 스터디 식별정보를 알려주세요") Long studyId,
-        @ValueOfEnum(enumClass = PostCategory.class, message = "카테고리는 NOTICE 또는 GENERAL 이어야 합니다") String category
+        @ValueOfEnum(codeMappingEnumClass = PostCategory.class, message = "카테고리는 NOTICE 또는 GENERAL 이어야 합니다") String category
     ) implements PostRequest {
 
         @Builder
@@ -26,7 +26,7 @@ public sealed interface PostRequest permits Search, Create, Edit {
         String title,
         @Size(max = 6000, message = "게시글 본문은 6,000자 이내로 작성해 주세요")
         String content,
-        @ValueOfEnum(enumClass = PostCategory.class) @Size(max = 20, message = "카테고리 이름은 20자 이내여야 합니다")
+        @ValueOfEnum(codeMappingEnumClass = PostCategory.class) @Size(max = 20, message = "카테고리 이름은 20자 이내여야 합니다")
         String category,
         Long studyId
     ) implements PostRequest {

--- a/src/main/java/com/devcourse/checkmoi/domain/post/model/PostCategory.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/post/model/PostCategory.java
@@ -2,18 +2,29 @@ package com.devcourse.checkmoi.domain.post.model;
 
 import com.devcourse.checkmoi.domain.study.model.StudyMember;
 import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import com.devcourse.checkmoi.global.annotation.CodeMappable;
 import java.util.Set;
 
-public enum PostCategory {
-    NOTICE(Set.of(StudyMemberStatus.OWNED)),
-    GENERAL(Set.of(StudyMemberStatus.OWNED, StudyMemberStatus.ACCEPTED)),
-    BOOK_REVIEW(Set.of(StudyMemberStatus.OWNED, StudyMemberStatus.ACCEPTED));
+public enum PostCategory implements CodeMappable {
+    NOTICE("NOTICE", Set.of(StudyMemberStatus.OWNED)),
+    GENERAL("GENERAL", Set.of(StudyMemberStatus.OWNED, StudyMemberStatus.ACCEPTED)),
+    BOOK_REVIEW("BOOK_REVIEW", Set.of(StudyMemberStatus.OWNED, StudyMemberStatus.ACCEPTED));
 
     private final Set<StudyMemberStatus> allowedMembers;
 
+    private final String code;
+
     PostCategory(
+        String code,
         Set<StudyMemberStatus> allowedMembers) {
+
+        this.code = code;
         this.allowedMembers = allowedMembers;
+    }
+
+    @Override
+    public String getMappingCode() {
+        return this.code;
     }
 
     public boolean isAllowedWriter(StudyMember member) {

--- a/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyRequest.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/dto/StudyRequest.java
@@ -23,8 +23,8 @@ public sealed interface StudyRequest permits Create, Edit, Audit, Search {
         @Nullable Long studyId,
         @Nullable Long bookId,
         @Nullable Boolean isMember,
-        @Nullable @ValueOfEnum(enumClass = StudyMemberStatus.class) String memberStatus,
-        @Nullable @ValueOfEnum(enumClass = StudyStatus.class) String studyStatus
+        @Nullable @ValueOfEnum(codeMappingEnumClass = StudyMemberStatus.class) String memberStatus,
+        @Nullable @ValueOfEnum(codeMappingEnumClass = StudyStatus.class) String studyStatus
     ) implements StudyRequest {
 
         @Builder
@@ -74,7 +74,7 @@ public sealed interface StudyRequest permits Create, Edit, Audit, Search {
     }
 
     record Audit(
-        @ValueOfEnum(enumClass = StudyMemberStatus.class) String status
+        @ValueOfEnum(codeMappingEnumClass = StudyMemberStatus.class) String status
     ) implements StudyRequest {
 
         @Builder

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyMemberStatus.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyMemberStatus.java
@@ -1,9 +1,21 @@
 package com.devcourse.checkmoi.domain.study.model;
 
-public enum StudyMemberStatus {
-    PENDING,
-    ACCEPTED,
-    DENIED,
-    OWNED
+import com.devcourse.checkmoi.global.annotation.CodeMappable;
 
+public enum StudyMemberStatus implements CodeMappable {
+    PENDING("PENDING"),
+    ACCEPTED("ACCEPTED"),
+    DENIED("DENIED"),
+    OWNED("OWNED");
+
+    private final String code;
+
+    StudyMemberStatus(String code) {
+        this.code = code;
+    }
+
+    @Override
+    public String getMappingCode() {
+        return this.code;
+    }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyStatus.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/model/StudyStatus.java
@@ -1,33 +1,48 @@
 package com.devcourse.checkmoi.domain.study.model;
 
-import java.util.Arrays;
+import com.devcourse.checkmoi.global.annotation.CodeMappable;
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
-public enum StudyStatus {
-    RECRUITING("RECRUITING",
+public enum StudyStatus implements CodeMappable {
+    RECRUITING("recruiting",
         Set.of(NextStatus.IN_PROGRESS, NextStatus.RECRUITING_FINISHED)),
-    RECRUITING_FINISHED("RECRUITINGFINISHED",
+    RECRUITING_FINISHED("recruitingFinished",
         Set.of(NextStatus.IN_PROGRESS)),
-    IN_PROGRESS("INPROGRESS",
+    IN_PROGRESS("inProgress",
         Set.of(NextStatus.FINISHED)),
-    FINISHED("FINISHED",
+    FINISHED("finished",
         Collections.emptySet());
 
-    private final String name;
+    private static final Map<String, StudyStatus> strToStudyStatus = new HashMap<>();
+
+    static {
+        strToStudyStatus.put(RECRUITING.getMappingCode(), RECRUITING);
+        strToStudyStatus.put(RECRUITING_FINISHED.getMappingCode(), RECRUITING_FINISHED);
+        strToStudyStatus.put(IN_PROGRESS.getMappingCode(), IN_PROGRESS);
+        strToStudyStatus.put(FINISHED.getMappingCode(), FINISHED);
+    }
+
+    private final String code;
 
     private final Set<NextStatus> allowedNextStatus;
 
-    StudyStatus(String name, Set<NextStatus> allowedNextStatus) {
-        this.name = name;
+    StudyStatus(String code, Set<NextStatus> allowedNextStatus) {
+        this.code = code;
         this.allowedNextStatus = allowedNextStatus;
     }
 
-    public static StudyStatus nameOf(String name) {
-        return Arrays.stream(values())
-            .filter(value -> value.name.equals(name.toUpperCase()))
-            .findFirst()
-            .orElse(null);
+    public static StudyStatus nameOf(String inputCode) {
+        return strToStudyStatus.getOrDefault(inputCode, null);
+    }
+
+    @JsonValue
+    @Override
+    public String getMappingCode() {
+        return this.code;
     }
 
     public boolean isAllowedToChangeStatus(StudyStatus status) {
@@ -54,10 +69,5 @@ public enum StudyStatus {
             return NextStatus.valueOf(status.name());
         }
 
-    }
-
-    @Override
-    public String toString() {
-        return name;
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepositoryImpl.java
@@ -78,7 +78,7 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
             .from(study)
             .where(
                 eqBookId(bookId),
-                eqStudyStatus(RECRUITING.toString())
+                eqStudyStatus(RECRUITING.getMappingCode())
             );
 
         List<StudyInfo> studies = query
@@ -153,7 +153,7 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
                 .on(studyMember.study.id.eq(study.id))
                 .where(
                     eqUserId(userId),
-                    eqStudyMemberStatus(OWNED.toString())
+                    eqStudyMemberStatus(OWNED.name())
                 )
                 .fetch(), 0
         );

--- a/src/main/java/com/devcourse/checkmoi/global/annotation/CodeMappable.java
+++ b/src/main/java/com/devcourse/checkmoi/global/annotation/CodeMappable.java
@@ -1,0 +1,6 @@
+package com.devcourse.checkmoi.global.annotation;
+
+public interface CodeMappable {
+
+    String getMappingCode();
+}

--- a/src/main/java/com/devcourse/checkmoi/global/annotation/ValueOfEnum.java
+++ b/src/main/java/com/devcourse/checkmoi/global/annotation/ValueOfEnum.java
@@ -16,7 +16,8 @@ import javax.validation.Payload;
 @Retention(RUNTIME)
 @Constraint(validatedBy = ValueOfEnumValidator.class)
 public @interface ValueOfEnum {
-    Class<? extends Enum<?>> enumClass();
+
+    Class<? extends CodeMappable> codeMappingEnumClass();
 
     String message() default "존재하지 않는 enum 값 입니다";
 

--- a/src/main/java/com/devcourse/checkmoi/global/annotation/ValueOfEnumValidator.java
+++ b/src/main/java/com/devcourse/checkmoi/global/annotation/ValueOfEnumValidator.java
@@ -17,12 +17,10 @@ public class ValueOfEnumValidator implements ConstraintValidator<ValueOfEnum, St
         if (value == null) {
             return true;
         }
-        Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+        Object[] enumValues = this.annotation.codeMappingEnumClass().getEnumConstants();
         if (enumValues != null) {
             for (Object enumValue : enumValues) {
-                if (value.equals(enumValue.toString())
-                    || (this.annotation.ignoreCase() && value.equalsIgnoreCase(
-                    enumValue.toString()))) {
+                if (value.equals(((CodeMappable) enumValue).getMappingCode())) {
                     return true;
                 }
             }
@@ -31,4 +29,3 @@ public class ValueOfEnumValidator implements ConstraintValidator<ValueOfEnum, St
     }
 
 }
-

--- a/src/test/java/com/devcourse/checkmoi/domain/book/api/BookApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/book/api/BookApiTest.java
@@ -300,7 +300,7 @@ class BookApiTest extends IntegrationTest {
 
     @Nested
     @DisplayName("책 검색 v2")
-    class SearchBooks {
+    class SearchBooksTest {
 
         private BookInfo makeBookInfo(Book book) {
             return BookInfo.builder()
@@ -334,7 +334,7 @@ class BookApiTest extends IntegrationTest {
 
             Search search = Search.builder()
                 .studyId(study.getId())
-                .studyStatus(study.getStatus().toString())
+                .studyStatus(study.getStatus().getMappingCode())
                 .build();
 
             MultiValueMap<String, String> params = new LinkedMultiValueMap<>();

--- a/src/test/java/com/devcourse/checkmoi/domain/book/repository/BookRepositoryTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/book/repository/BookRepositoryTest.java
@@ -95,7 +95,7 @@ class BookRepositoryTest extends RepositoryTest {
         private List<Study> studies = new ArrayList<>();
 
         @BeforeEach
-        void setUp() throws InterruptedException {
+        void setUp() {
             tearDown();
 
             books.add(bookRepository.save(makeBook()));
@@ -127,7 +127,7 @@ class BookRepositoryTest extends RepositoryTest {
         void searchStudies() {
             Search search = Search.builder()
                 .bookId(books.get(0).getId())
-                .studyStatus(IN_PROGRESS.toString())
+                .studyStatus(IN_PROGRESS.getMappingCode())
                 .build();
 
             SimplePage page = SimplePage.builder().build();

--- a/src/test/java/com/devcourse/checkmoi/domain/post/service/PostCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/post/service/PostCommandServiceImplTest.java
@@ -75,7 +75,7 @@ class PostCommandServiceImplTest {
             Post post = makePostWithId(GENERAL, study, user, 3L);
 
             PostRequest.Create request = Create.builder().title(post.getTitle())
-                .content(post.getContent()).category(post.getCategory().toString())
+                .content(post.getContent()).category(post.getCategory().getMappingCode())
                 .studyId(study.getId()).build();
 
             given(studyMemberRepository.findWithStudyByUserAndStudy(any(), anyLong())).willReturn(
@@ -99,7 +99,7 @@ class PostCommandServiceImplTest {
             Post post = makePostWithId(PostCategory.GENERAL, study, user, 3L);
 
             PostRequest.Create request = Create.builder().title(post.getTitle())
-                .content(post.getContent()).category(post.getCategory().toString())
+                .content(post.getContent()).category(post.getCategory().getMappingCode())
                 .studyId(study.getId()).build();
 
             given(studyMemberRepository.findWithStudyByUserAndStudy(any(), anyLong())).willReturn(
@@ -121,7 +121,7 @@ class PostCommandServiceImplTest {
             Post post = makePostWithId(PostCategory.NOTICE, study, user, 3L);
 
             PostRequest.Create request = Create.builder().title(post.getTitle())
-                .content(post.getContent()).category(post.getCategory().toString())
+                .content(post.getContent()).category(post.getCategory().getMappingCode())
                 .studyId(study.getId()).build();
 
             given(studyMemberRepository.findWithStudyByUserAndStudy(any(), anyLong())).willReturn(
@@ -143,7 +143,7 @@ class PostCommandServiceImplTest {
             Post post = makePostWithId(PostCategory.NOTICE, study, user, 3L);
 
             PostRequest.Create request = Create.builder().title(post.getTitle())
-                .content(post.getContent()).category(post.getCategory().toString())
+                .content(post.getContent()).category(post.getCategory().getMappingCode())
                 .studyId(study.getId()).build();
 
             given(studyMemberRepository.findWithStudyByUserAndStudy(any(), anyLong())).willReturn(

--- a/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
@@ -43,7 +43,6 @@ import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.service.StudyCommandService;
 import com.devcourse.checkmoi.domain.study.service.StudyQueryService;
 import com.devcourse.checkmoi.domain.token.dto.TokenResponse.TokenWithUserInfo;
-import com.devcourse.checkmoi.global.model.SimplePage;
 import com.devcourse.checkmoi.template.IntegrationTest;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
@@ -172,7 +171,7 @@ class StudyApiTest extends IntegrationTest {
                 .name("스터디 이름")
                 .thumbnail("https://example.com")
                 .description("스터디 설명")
-                .status("IN_PROGRESS")
+                .status("inProgress")
                 .build();
             Long requestId = 1L;
 
@@ -719,7 +718,7 @@ class StudyApiTest extends IntegrationTest {
 
     @Nested
     @DisplayName("스터디 조회 v2 #158")
-    class SearchStudies {
+    class SearchStudiesTest {
 
         private StudyInfo makeStudyInfo(Study study) {
             return StudyInfo.builder()
@@ -752,9 +751,9 @@ class StudyApiTest extends IntegrationTest {
                 );
 
             Search search = Search.builder()
-                .studyStatus(FINISHED.toString())
+                .studyStatus(FINISHED.getMappingCode())
                 // For Coverage
-                .memberStatus(OWNED.toString())
+                .memberStatus(OWNED.getMappingCode())
                 .userId(1L)
                 .studyId(1L)
                 .bookId(1L)

--- a/src/test/java/com/devcourse/checkmoi/domain/study/repository/StudyRepositoryTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/repository/StudyRepositoryTest.java
@@ -439,8 +439,8 @@ class StudyRepositoryTest extends RepositoryTest {
             Search search = Search.builder()
                 .bookId(book.getId())
                 .isMember(true)
-                .studyStatus(IN_PROGRESS.toString())
-                .memberStatus(ACCEPTED.toString())
+                .studyStatus(IN_PROGRESS.getMappingCode())
+                .memberStatus(ACCEPTED.getMappingCode())
                 .build();
             SimplePage page = SimplePage.builder().build();
 
@@ -473,7 +473,7 @@ class StudyRepositoryTest extends RepositoryTest {
             Search search = Search.builder()
                 .userId(givenUser.getId())
                 .studyStatus("recruiting")
-                .memberStatus("owned")
+                .memberStatus("OWNED")
                 .build();
             SimplePage page = SimplePage.builder().build();
 

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
@@ -136,7 +136,7 @@ class StudyCommandServiceImplTest {
                 .name("스터디 이름")
                 .thumbnail("https://example.com")
                 .description("스터디 설명")
-                .status(IN_PROGRESS.toString())
+                .status(IN_PROGRESS.getMappingCode())
                 .build();
             Long userId = 1L;
             Long studyId = 1L;


### PR DESCRIPTION
sequencegenerator 
## 작업사항
> 💥 현재상황은 열거타입 마다 프론트와 조율한 문자열의 형태가 다른 상황
아래 문자열로 "서버에 들어오고", "서버에서 보내줘야" 하는 상황
```java
@@@@@게시글 카테고리@@@@@
NOTICE
GENERAL
```

```java

@@@@@스터디 상태@@@@@
recruiting
recruitingFinished
inProgress
finished
```

```java
@@@@@스터디멤버 상태 @@@@@
ACCEPTED
DENIED
OWNED
```

---------------------


- 공통적인 처리를 하려면 공통 타입으로 처리할 수 있도록 하는게 좋을 거라 생각했습니다
- 기존의 Enum 타입으로 변환할 문자열들에 대한 검증을 수행하는 검증기도 변경함 ( CodeMappable 인터페이스의 메소드를 사용하여 검증함)
- StudyStatus 의 정적 팩토리 로직을 수정했습니다 ( nameOf 정적 팩토리 메소드가 사실상 CustomRepositoryImpl 에서만 사용되기는 하지만, 현재 얘가 null 을 반환하는 게 쪼끔 찝찝 하네요 ) 
- @JsonValue -> 직렬화시에 사용할 메소드를 지정합니다. ( StudyStatus 처럼 카멜케이스로 반환 요청 받은 애들은 , getMappingCode() 를 @JsonValue 로 설정해줘야 합니다 ) 
- ValueOfEnumValidator 로직을 변경하였습니다 -> CodeMappable 인터페이스 명세에 있는 메소드를 사용하도록
- 제가 생각하면서 변경을 한 부분들은 
	-   비교 할 때는 모두 getOutput() 사용해서 비교
	-   만들 때는
	    -   대문자로 받는 애들은 valueOf 로 하면 되고
	    -   카멜로 들어오는 애들은 정적 팩토리 메소드 사용
-   DB 에 넣을 때는, name() 을 사용
    -   Enum 의 name() 은 final 메소드이니까.. 현재 저희는 Enumerated 의 String 전략을 사용하고 있으니, DB 와 비교할 때는 name() 을 사용하는게 안전할 거라 생각했습니다.


<img width="444" alt="Screen Shot 2022-08-12 at 11 27 46 PM" src="https://user-images.githubusercontent.com/53856184/184375095-ce19cab1-f69e-4887-aa07-37490a44d8c7.png">
메소드 로직을 수정함
## 중점적으로 봐야할 부분

- resolves #202
