### PR TITLE
✨ feat :  이미지 용량 초과 예외메시지 추가 (#173)

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/global/exception/error/ErrorMessage.java
+++ b/src/main/java/com/devcourse/checkmoi/global/exception/error/ErrorMessage.java
@@ -30,6 +30,7 @@ public enum ErrorMessage {
 
     // file error
     NOT_ALLOWED_FILE("허용할 수 없는 파일입니다", HttpStatus.BAD_REQUEST),
+    FILE_SIZE_EXCEED("파일 크기는 1MB 를 넘을 수 없습니다", HttpStatus.PAYLOAD_TOO_LARGE),
 
     // study error
     NOT_ALLOWED_STUDY_STATUS("스터디 상태 변경을 할 수 없습니다", HttpStatus.BAD_REQUEST),
@@ -44,6 +45,7 @@ public enum ErrorMessage {
 
     //comment error
     COMMENT_NO_PERMISSION("해당 댓글에 대한 접근 권한이 없습니다", HttpStatus.FORBIDDEN);
+
     private final String message;
 
     private final HttpStatus status;

--- a/src/main/java/com/devcourse/checkmoi/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/devcourse/checkmoi/global/exception/handler/GlobalExceptionHandler.java
@@ -4,11 +4,13 @@ import com.devcourse.checkmoi.global.exception.BusinessException;
 import com.devcourse.checkmoi.global.exception.error.ErrorMessage;
 import com.devcourse.checkmoi.global.exception.error.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MultipartException;
 
 @Slf4j
 @RestControllerAdvice
@@ -53,6 +55,16 @@ public class GlobalExceptionHandler {
         ErrorResponse response = ErrorResponse.of(e);
 
         return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(MultipartException.class)
+    protected ResponseEntity<ErrorResponse> handleFileSizeException(MultipartException e) {
+        log.error("{}", e.getMessage());
+
+        ErrorResponse response = ErrorResponse.of(ErrorMessage.FILE_SIZE_EXCEED);
+
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
+            .body(response);
     }
 
 }


### PR DESCRIPTION
## 작업사항

용량 초과의 이미지 업로드 시 기존의 모습은 아래와 같았습니다
![Screen Shot 2022-08-13 at 3 09 47 PM](https://user-images.githubusercontent.com/53856184/184471193-28bee224-d9af-4279-a98e-9d1eccc63f1e.png)


예외메시지를 출력하는 것으로 처리하였습니다
![Screen Shot 2022-08-13 at 3 12 55 PM](https://user-images.githubusercontent.com/53856184/184471292-bb9adf77-cd6e-40d1-8969-305fbba10297.png)

이력서 쓸 때 크기가 큰 이미지 첨부시 용량 초과 에러메시지 뜨는 것 처럼 생각하면 좋을듯 합니당

예외메시지를 추가하고 GlobalExceptionHandler 에서 해당 예외를 처리하도록 추가하였습니다

비동기로 변경하는 PR 과 분리하여 올립니다!

## 중점적으로 봐야할 부분

- resolves #173 
