### PR TITLE
✨ feat :  진행기간이 지난 스터디들을 진행완료상태로 변경하는 기능 추가 (#173)

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepository.java
@@ -29,7 +29,7 @@ public interface CustomStudyRepository {
 
     Page<StudyInfo> findAllByCondition(Search search, Pageable pageable);
 
-    ExpiredStudies getAllTobeProgressed(LocalDate current, StudyStatus toStatus);
+    ExpiredStudies getAllTobeProcessed(LocalDate current, StudyStatus toStatus);
 
     void updateStudyStatus(Long studyId, StudyStatus studyStatus);
 

--- a/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/repository/CustomStudyRepositoryImpl.java
@@ -160,9 +160,10 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
     }
 
     @Override
-    public ExpiredStudies getAllTobeProgressed(LocalDate current, StudyStatus toStatus) {
+    public ExpiredStudies getAllTobeProcessed(LocalDate current, StudyStatus toStatus) {
         return switch (toStatus) {
             case IN_PROGRESS -> findAllToBeProgressed(current);
+            case FINISHED -> findAllToBeFinished(current);
             default -> new ExpiredStudies(Collections.emptyList());
         };
     }
@@ -197,6 +198,18 @@ public class CustomStudyRepositoryImpl implements CustomStudyRepository {
                     study.studyStartDate.between(null, current),
                     study.status.eq(RECRUITING)
                         .or(study.status.eq(RECRUITING_FINISHED))
+                ).fetch()
+        );
+    }
+
+    private ExpiredStudies findAllToBeFinished(LocalDate current) {
+        return new ExpiredStudies(
+            jpaQueryFactory
+                .select(study.id)
+                .from(study)
+                .where(
+                    study.studyEndDate.before(current),
+                    study.status.ne(StudyStatus.FINISHED)
                 ).fetch()
         );
     }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyQueryServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyQueryServiceImpl.java
@@ -86,7 +86,7 @@ public class StudyQueryServiceImpl implements StudyQueryService {
 
     @Override
     public ExpiredStudies getAllExpiredStudies(LocalDate criteriaTime, StudyStatus toStatus) {
-        return studyRepository.getAllTobeProgressed(criteriaTime, toStatus);
+        return studyRepository.getAllTobeProcessed(criteriaTime, toStatus);
     }
 
     /******************* Validate *******************/

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/schedule/StudyScheduleService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/schedule/StudyScheduleService.java
@@ -31,8 +31,14 @@ public class StudyScheduleService implements ScheduleManager {
     }
 
     @Override
-    public ExpiredStudies getAllStudiesToBeProgressed() {
+    @Transactional
+    public void updateStudy(Long studyId, StudyStatus studyStatus) {
+        studyCommandService.updateStudyStatus(studyId, studyStatus);
+    }
 
-        return studyQueryService.getAllExpiredStudies(LocalDate.now(), StudyStatus.IN_PROGRESS);
+    @Override
+    public ExpiredStudies getAllStudiesToBeProcessed(StudyStatus toStatus) {
+
+        return studyQueryService.getAllExpiredStudies(LocalDate.now(), toStatus);
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/global/scheduler/ScheduleManager.java
+++ b/src/main/java/com/devcourse/checkmoi/global/scheduler/ScheduleManager.java
@@ -9,5 +9,7 @@ public interface ScheduleManager {
     void updateStudyWithMembers(Long studyId, StudyStatus studyStatus,
         StudyMemberStatus memberStatus);
 
-    ExpiredStudies getAllStudiesToBeProgressed();
+    void updateStudy(Long studyId, StudyStatus studyStatus);
+
+    ExpiredStudies getAllStudiesToBeProcessed(StudyStatus toStatus);
 }

--- a/src/main/java/com/devcourse/checkmoi/global/scheduler/Scheduler.java
+++ b/src/main/java/com/devcourse/checkmoi/global/scheduler/Scheduler.java
@@ -20,7 +20,7 @@ public class Scheduler {
 
     @Scheduled(cron = "0 0 0 * * *")
     void changeStudyAsInProgress() {
-        log.info(message + " 스터디 상태 변경 작업 시작");
+        log.info(message + " 스터디 상태 변경 작업 (-> 진행 중 ) 시작");
 
         try {
             progressStudies();
@@ -31,11 +31,30 @@ public class Scheduler {
         log.info(message + " 스터디 상태 변경 작업 완료!!");
     }
 
+    @Scheduled(cron = "0 0 0 * * *")
+    void changeStudyAsFinished() {
+        log.info(message + " 스터디 상태 변경 작업 (-> 진행 완료 ) 시작");
+
+        try {
+            completeStudies();
+        } catch (Exception e) {
+            log.error(message + "[ERROR] : 스터디를 진행중 상태로 변경하는 스케줄링 작업 실패", e);
+        }
+
+        log.info(message + " 스터디 상태 변경 작업 완료!!");
+    }
+
     private void progressStudies() {
-        studyManager.getAllStudiesToBeProgressed().studies()
+        studyManager.getAllStudiesToBeProcessed(StudyStatus.IN_PROGRESS).studies()
             .forEach(studyId ->
                 studyManager.updateStudyWithMembers(studyId, StudyStatus.IN_PROGRESS,
                     StudyMemberStatus.DENIED));
+    }
+
+    private void completeStudies() {
+        studyManager.getAllStudiesToBeProcessed(StudyStatus.FINISHED).studies()
+            .forEach(studyId ->
+                studyManager.updateStudy(studyId, StudyStatus.FINISHED));
     }
 
 }


### PR DESCRIPTION
## 작업사항
스터디 진행 종료 날짜가 지난 스터디들을 진행완료 상태로 변경합니다.
각 상태변경은 각각의 트랜잭션에서 이루어집니다.
기존 스케줄러 태스크와 비동기적으로 동작합니다 
추가적인 로직에 대한 테스트 추가


## 중점적으로 봐야할 부분
커밋메시지에 이슈번호를 잘못 적었습니다

- resolves #224 
