### PR TITLE
♻️ refactor : 현재 유저가 스터디에 최대 스터디수 만큼 가입했을 경우 예외 처리

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/api/StudyApi.java
@@ -93,7 +93,7 @@ public class StudyApi {
         @PathVariable Long studyId,
         @AuthenticationPrincipal JwtAuthentication user
     ) {
-        Long studyMemberId = studyCommandService.requestStudyJoin(studyId, user.id());
+        Long studyMemberId = studyFacade.requestStudyJoin(studyId, user.id());
         return ResponseEntity.ok()
             .body(new SuccessResponse<>(studyMemberId));
     }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/exception/StudyJoinMaximumReachedException.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/exception/StudyJoinMaximumReachedException.java
@@ -1,0 +1,11 @@
+package com.devcourse.checkmoi.domain.study.exception;
+
+import com.devcourse.checkmoi.global.exception.InvalidStatusException;
+import com.devcourse.checkmoi.global.exception.error.ErrorMessage;
+
+public class StudyJoinMaximumReachedException extends InvalidStatusException {
+
+    public StudyJoinMaximumReachedException() {
+        super(ErrorMessage.STUDY_JOIN_MAXIMUM_REACHED);
+    }
+}

--- a/src/main/java/com/devcourse/checkmoi/domain/study/facade/StudyFacade.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/facade/StudyFacade.java
@@ -12,4 +12,6 @@ public interface StudyFacade {
     Long createStudy(Create request, Long userId);
 
     Studies getStudies(Long bookId, Pageable pageable);
+
+    Long requestStudyJoin(Long studyId, Long userId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/facade/StudyFacadeImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/facade/StudyFacadeImpl.java
@@ -40,6 +40,8 @@ public class StudyFacadeImpl implements StudyFacade {
     @Override
     public Long createStudy(Create request, Long userId) {
         bookQueryService.getById(request.bookId());
+        int joinStudies = userQueryService.userJoinedStudies(userId);
+        studyValidator.validateMaximumJoinStudy(joinStudies);
         return studyCommandService.createStudy(request, userId);
     }
 

--- a/src/main/java/com/devcourse/checkmoi/domain/study/facade/StudyFacadeImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/facade/StudyFacadeImpl.java
@@ -7,7 +7,6 @@ import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
 import com.devcourse.checkmoi.domain.study.service.StudyCommandService;
 import com.devcourse.checkmoi.domain.study.service.StudyQueryService;
 import com.devcourse.checkmoi.domain.study.service.validator.StudyValidator;
-import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfoWithStudy;
 import com.devcourse.checkmoi.domain.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -40,7 +39,7 @@ public class StudyFacadeImpl implements StudyFacade {
     @Override
     public Long createStudy(Create request, Long userId) {
         bookQueryService.getById(request.bookId());
-        int joinStudies = userQueryService.userJoinedStudies(userId);
+        int joinStudies = userQueryService.getUserJoinedStudies(userId);
         studyValidator.validateMaximumJoinStudy(joinStudies);
         return studyCommandService.createStudy(request, userId);
     }
@@ -53,7 +52,7 @@ public class StudyFacadeImpl implements StudyFacade {
 
     @Override
     public Long requestStudyJoin(Long studyId, Long userId) {
-        int joinStudies = userQueryService.userJoinedStudies(userId);
+        int joinStudies = userQueryService.getUserJoinedStudies(userId);
         studyValidator.validateMaximumJoinStudy(joinStudies);
         return studyCommandService.requestStudyJoin(studyId, userId);
     }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/facade/StudyFacadeImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/facade/StudyFacadeImpl.java
@@ -6,6 +6,8 @@ import com.devcourse.checkmoi.domain.study.dto.StudyResponse.MyStudies;
 import com.devcourse.checkmoi.domain.study.dto.StudyResponse.Studies;
 import com.devcourse.checkmoi.domain.study.service.StudyCommandService;
 import com.devcourse.checkmoi.domain.study.service.StudyQueryService;
+import com.devcourse.checkmoi.domain.study.service.validator.StudyValidator;
+import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfoWithStudy;
 import com.devcourse.checkmoi.domain.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +24,8 @@ public class StudyFacadeImpl implements StudyFacade {
     private final UserQueryService userQueryService;
 
     private final BookQueryService bookQueryService;
+
+    private final StudyValidator studyValidator;
 
     @Override
     public MyStudies getMyStudies(Long userId) {
@@ -43,5 +47,12 @@ public class StudyFacadeImpl implements StudyFacade {
     public Studies getStudies(Long bookId, Pageable pageable) {
         bookQueryService.getById(bookId);
         return studyQueryService.getStudies(bookId, pageable);
+    }
+
+    @Override
+    public Long requestStudyJoin(Long studyId, Long userId) {
+        int joinStudies = userQueryService.userJoinedStudies(userId);
+        studyValidator.validateMaximumJoinStudy(joinStudies);
+        return studyCommandService.requestStudyJoin(studyId, userId);
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImpl.java
@@ -97,11 +97,9 @@ public class StudyCommandServiceImpl implements StudyCommandService {
     public Long requestStudyJoin(Long studyId, Long userId) {
         Study study = studyRepository.findById(studyId)
             .orElseThrow(StudyNotFoundException::new);
-        User user = userRepository.findById(userId)
-            .orElseThrow(UserNotFoundException::new);
         studyValidator.validateRecruitingStudy(study);
         studyValidator.validateFullMemberStudy(study);
-        StudyMember request = studyMemberRepository.findByUserAndStudy(user.getId(), studyId)
+        StudyMember request = studyMemberRepository.findByUserAndStudy(userId, studyId)
             .map(studyMember -> {
                 studyValidator.validateDuplicateStudyMemberRequest(studyMember);
                 studyMember.changeStatus(StudyMemberStatus.PENDING);
@@ -110,7 +108,7 @@ public class StudyCommandServiceImpl implements StudyCommandService {
             .orElseGet(() ->
                 StudyMember.builder()
                     .study(study)
-                    .user(user)
+                    .user(User.builder().id(userId).build())
                     .status(StudyMemberStatus.PENDING)
                     .build()
             );

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/validator/StudyValidator.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/validator/StudyValidator.java
@@ -1,6 +1,5 @@
 package com.devcourse.checkmoi.domain.study.service.validator;
 
-import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Audit;
 import com.devcourse.checkmoi.domain.study.model.Study;
 import com.devcourse.checkmoi.domain.study.model.StudyMember;
 
@@ -19,4 +18,6 @@ public interface StudyValidator {
     void validateRecruitingStudy(Study study);
 
     void validateFullMemberStudy(Study study);
+
+    void validateMaximumJoinStudy(int joinStudy);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/service/validator/StudyValidatorImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/service/validator/StudyValidatorImpl.java
@@ -7,6 +7,7 @@ import com.devcourse.checkmoi.domain.study.exception.FinishedStudyException;
 import com.devcourse.checkmoi.domain.study.exception.NotJoinedMemberException;
 import com.devcourse.checkmoi.domain.study.exception.NotRecruitingStudyException;
 import com.devcourse.checkmoi.domain.study.exception.NotStudyOwnerException;
+import com.devcourse.checkmoi.domain.study.exception.StudyJoinMaximumReachedException;
 import com.devcourse.checkmoi.domain.study.exception.StudyMemberFullException;
 import com.devcourse.checkmoi.domain.study.exception.StudyNotFoundException;
 import com.devcourse.checkmoi.domain.study.model.Study;
@@ -63,6 +64,14 @@ public class StudyValidatorImpl implements StudyValidator {
     public void validateFullMemberStudy(Study study) {
         if (study.getCurrentParticipant() >= study.getMaxParticipant()) {
             throw new StudyMemberFullException();
+        }
+    }
+
+    @Override
+    public void validateMaximumJoinStudy(int joinStudy) {
+        final int JOIN_MAX_STUDY = 10;
+        if (joinStudy >= JOIN_MAX_STUDY) {
+            throw new StudyJoinMaximumReachedException();
         }
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/user/repository/CustomUserRepository.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/user/repository/CustomUserRepository.java
@@ -5,4 +5,6 @@ import com.devcourse.checkmoi.domain.user.dto.UserResponse.UserInfoWithStudy;
 public interface CustomUserRepository {
 
     UserInfoWithStudy findUserInfoWithStudy(Long userId);
+
+    int userJoinedStudies(Long userId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/user/repository/CustomUserRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/user/repository/CustomUserRepositoryImpl.java
@@ -35,6 +35,11 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
             .build();
     }
 
+    @Override
+    public int userJoinedStudies(Long userId) {
+        return getUserStudiesInfo(userId, 10).size();
+    }
+
     private List<StudyInfo> getUserStudiesInfo(Long userId, int limit) {
         return jpaQueryFactory.select(
                 Projections.constructor(

--- a/src/main/java/com/devcourse/checkmoi/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/user/service/UserQueryService.java
@@ -9,4 +9,5 @@ public interface UserQueryService {
 
     UserInfoWithStudy findUserInfoWithStudy(Long id);
 
+    int userJoinedStudies(Long userId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/user/service/UserQueryService.java
@@ -9,5 +9,5 @@ public interface UserQueryService {
 
     UserInfoWithStudy findUserInfoWithStudy(Long id);
 
-    int userJoinedStudies(Long userId);
+    int getUserJoinedStudies(Long userId);
 }

--- a/src/main/java/com/devcourse/checkmoi/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/user/service/UserQueryServiceImpl.java
@@ -31,7 +31,7 @@ public class UserQueryServiceImpl implements UserQueryService {
     }
 
     @Override
-    public int userJoinedStudies(Long userId) {
+    public int getUserJoinedStudies(Long userId) {
         return userRepository.userJoinedStudies(userId);
     }
 

--- a/src/main/java/com/devcourse/checkmoi/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/user/service/UserQueryServiceImpl.java
@@ -30,4 +30,9 @@ public class UserQueryServiceImpl implements UserQueryService {
         return userRepository.findUserInfoWithStudy(userId);
     }
 
+    @Override
+    public int userJoinedStudies(Long userId) {
+        return userRepository.userJoinedStudies(userId);
+    }
+
 }

--- a/src/main/java/com/devcourse/checkmoi/global/exception/error/ErrorMessage.java
+++ b/src/main/java/com/devcourse/checkmoi/global/exception/error/ErrorMessage.java
@@ -38,7 +38,7 @@ public enum ErrorMessage {
     NOT_JOINED_USER("해당 스터디에 참가하지 않은 유저입니다.", HttpStatus.FORBIDDEN),
     NOT_RECRUITING_STUDY("모집중인 스터디가 아닙니다.", HttpStatus.FORBIDDEN),
     STUDY_IS_FULL("해당 스터디는 모집인원이 가득찼습니다.", HttpStatus.FORBIDDEN),
-
+    STUDY_JOIN_MAXIMUM_REACHED("최대 스터디 가입 수에 도달하여 더 이상 가입할 수 없습니다.", HttpStatus.FORBIDDEN),
     // post error
     NOT_ALLOWED_WRITER("게시글 작성 권한이 없습니다", HttpStatus.FORBIDDEN),
     CLOSED_STUDY("종료된 스터디입니다. 자유게시판만 사용가능합니다", HttpStatus.BAD_REQUEST),

--- a/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/api/StudyApiTest.java
@@ -350,7 +350,7 @@ class StudyApiTest extends IntegrationTest {
             Long studyId = 1L;
             Long studyMemberId = 1L;
 
-            given(studyCommandService.requestStudyJoin(studyId, givenUser.userInfo().id()))
+            given(studyFacade.requestStudyJoin(studyId, givenUser.userInfo().id()))
                 .willReturn(studyMemberId);
 
             ResultActions result = mockMvc.perform(

--- a/src/test/java/com/devcourse/checkmoi/domain/study/facade/StudyFacadeImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/facade/StudyFacadeImplTest.java
@@ -13,7 +13,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import com.devcourse.checkmoi.domain.book.dto.BookResponse.BookInfo;
@@ -35,8 +34,6 @@ import com.devcourse.checkmoi.domain.user.service.UserQueryService;
 import com.devcourse.checkmoi.global.model.SimplePage;
 import java.time.LocalDate;
 import java.util.List;
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -138,7 +135,7 @@ class StudyFacadeImplTest {
 
             given(bookQueryService.getById(anyLong()))
                 .willReturn(bookInfo);
-            given(userQueryService.userJoinedStudies(anyLong()))
+            given(userQueryService.getUserJoinedStudies(anyLong()))
                 .willReturn(joinStudies);
             given(studyCommandService.createStudy(any(Create.class), anyLong()))
                 .willReturn(createdStudyId);
@@ -167,7 +164,7 @@ class StudyFacadeImplTest {
 
             given(bookQueryService.getById(anyLong()))
                 .willReturn(bookInfo);
-            given(userQueryService.userJoinedStudies(anyLong()))
+            given(userQueryService.getUserJoinedStudies(anyLong()))
                 .willReturn(maxJoinStudies);
             doThrow(StudyJoinMaximumReachedException.class)
                 .when(studyValidator)
@@ -224,7 +221,7 @@ class StudyFacadeImplTest {
         void requestStudyJoin() {
             Long studyMemberId = 1L;
             int joinStudies = 5;
-            given(userQueryService.userJoinedStudies(anyLong()))
+            given(userQueryService.getUserJoinedStudies(anyLong()))
                 .willReturn(joinStudies);
             given(studyCommandService.requestStudyJoin(anyLong(), anyLong()))
                 .willReturn(studyMemberId);
@@ -242,7 +239,7 @@ class StudyFacadeImplTest {
         void maximumJoinStudy() {
             int maxJoinStudies = 10;
 
-            given(userQueryService.userJoinedStudies(anyLong()))
+            given(userQueryService.getUserJoinedStudies(anyLong()))
                 .willReturn(maxJoinStudies);
             doThrow(StudyJoinMaximumReachedException.class)
                 .when(studyValidator)

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
@@ -418,7 +418,7 @@ class StudyCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("현재 모집중인 스터디만 가입 신청을 할 수 있습니다.")
+        @DisplayName("F 현재 모집중인 스터디가 아니라면 예외 발생")
         void recruitingStudy() {
             Study inProgressStudy = makeStudyWithId(book, IN_PROGRESS, study.getId());
 
@@ -433,7 +433,7 @@ class StudyCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("현재 스터디원이 최대치에 도달했을때 더 이상 신청을 할 수 없습니다")
+        @DisplayName("F 현재 스터디원이 최대치에 도달했을때 더 이상 신청을 할 수 없습니다")
         void fullMemberStudy() {
             given(studyRepository.findById(anyLong()))
                 .willReturn(Optional.of(study));

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
@@ -6,7 +6,6 @@ import static com.devcourse.checkmoi.domain.study.model.StudyStatus.IN_PROGRESS;
 import static com.devcourse.checkmoi.domain.study.model.StudyStatus.RECRUITING;
 import static com.devcourse.checkmoi.global.exception.error.ErrorMessage.ACCESS_DENIED;
 import static com.devcourse.checkmoi.global.exception.error.ErrorMessage.STUDY_JOIN_REQUEST_DUPLICATE;
-import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeBook;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeBookWithId;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudyMember;
 import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudyMemberWithId;
@@ -18,7 +17,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import com.devcourse.checkmoi.domain.book.model.Book;
@@ -38,7 +36,6 @@ import com.devcourse.checkmoi.domain.study.model.StudyStatus;
 import com.devcourse.checkmoi.domain.study.repository.StudyMemberRepository;
 import com.devcourse.checkmoi.domain.study.repository.StudyRepository;
 import com.devcourse.checkmoi.domain.study.service.validator.StudyValidator;
-import com.devcourse.checkmoi.domain.user.exception.UserNotFoundException;
 import com.devcourse.checkmoi.domain.user.model.User;
 import com.devcourse.checkmoi.domain.user.repository.UserRepository;
 import com.devcourse.checkmoi.global.exception.error.ErrorMessage;
@@ -364,8 +361,11 @@ class StudyCommandServiceImplTest {
     class RequestStudyJoinTest {
 
         Book book = makeBookWithId(1L);
+
         User user = makeUserWithId(1L);
+
         Study study = makeStudyWithId(book, RECRUITING, 1L);
+
         StudyMember studyMember = makeStudyMember(study, user, StudyMemberStatus.PENDING);
 
         @Test
@@ -413,7 +413,8 @@ class StudyCommandServiceImplTest {
                 .willReturn(Optional.empty());
 
             assertThatExceptionOfType(StudyNotFoundException.class)
-                .isThrownBy(() -> studyCommandService.requestStudyJoin(notExistStudyId, user.getId()));
+                .isThrownBy(
+                    () -> studyCommandService.requestStudyJoin(notExistStudyId, user.getId()));
         }
 
         @Test

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/StudyCommandServiceImplTest.java
@@ -350,8 +350,6 @@ class StudyCommandServiceImplTest {
         void requestStudyJoin() {
             given(studyRepository.findById(anyLong()))
                 .willReturn(Optional.of(study));
-            given(userRepository.findById(anyLong()))
-                .willReturn(Optional.of(user));
             given(studyMemberRepository.findByUserAndStudy(anyLong(), anyLong()))
                 .willReturn(Optional.empty());
             given(studyMemberRepository.save(any(StudyMember.class)))
@@ -371,8 +369,6 @@ class StudyCommandServiceImplTest {
 
             given(studyRepository.findById(anyLong()))
                 .willReturn(Optional.of(study));
-            given(userRepository.findById(anyLong()))
-                .willReturn(Optional.of(user));
             given(studyMemberRepository.findByUserAndStudy(anyLong(), anyLong()))
                 .willReturn(Optional.of(deniedMember));
             given(studyMemberRepository.save(any(StudyMember.class)))
@@ -398,27 +394,12 @@ class StudyCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("F 유저가 존재하지 않는다면 예외 발생")
-        void userNotFound() {
-            given(studyRepository.findById(anyLong()))
-                .willReturn(Optional.of(study));
-            given(userRepository.findById(anyLong()))
-                .willReturn(Optional.empty());
-
-            assertThatExceptionOfType(UserNotFoundException.class)
-                .isThrownBy(
-                    () -> studyCommandService.requestStudyJoin(study.getId(), user.getId()));
-        }
-
-        @Test
         @DisplayName("현재 모집중인 스터디만 가입 신청을 할 수 있습니다.")
         void recruitingStudy() {
             Study inProgressStudy = makeStudyWithId(book, IN_PROGRESS, study.getId());
 
             given(studyRepository.findById(anyLong()))
                 .willReturn(Optional.of(inProgressStudy));
-            given(userRepository.findById(anyLong()))
-                .willReturn(Optional.of(user));
             doThrow(NotRecruitingStudyException.class)
                 .when(studyValidator)
                 .validateRecruitingStudy(any(Study.class));
@@ -432,8 +413,6 @@ class StudyCommandServiceImplTest {
         void fullMemberStudy() {
             given(studyRepository.findById(anyLong()))
                 .willReturn(Optional.of(study));
-            given(userRepository.findById(anyLong()))
-                .willReturn(Optional.of(user));
             doThrow(StudyMemberFullException.class)
                 .when(studyValidator)
                 .validateFullMemberStudy(any(Study.class));
@@ -453,8 +432,6 @@ class StudyCommandServiceImplTest {
 
             given(studyRepository.findById(anyLong()))
                 .willReturn(Optional.of(study));
-            given(userRepository.findById(anyLong()))
-                .willReturn(Optional.of(user));
             given(studyMemberRepository.findByUserAndStudy(anyLong(), anyLong()))
                 .willReturn(Optional.of(studyMember));
 

--- a/src/test/java/com/devcourse/checkmoi/domain/study/service/validator/StudyValidatorImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/study/service/validator/StudyValidatorImplTest.java
@@ -14,12 +14,12 @@ import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeUser;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.devcourse.checkmoi.domain.book.model.Book;
-import com.devcourse.checkmoi.domain.study.dto.StudyRequest.Audit;
 import com.devcourse.checkmoi.domain.study.exception.DuplicateStudyJoinRequestException;
 import com.devcourse.checkmoi.domain.study.exception.FinishedStudyException;
 import com.devcourse.checkmoi.domain.study.exception.NotJoinedMemberException;
 import com.devcourse.checkmoi.domain.study.exception.NotRecruitingStudyException;
 import com.devcourse.checkmoi.domain.study.exception.NotStudyOwnerException;
+import com.devcourse.checkmoi.domain.study.exception.StudyJoinMaximumReachedException;
 import com.devcourse.checkmoi.domain.study.exception.StudyMemberFullException;
 import com.devcourse.checkmoi.domain.study.exception.StudyNotFoundException;
 import com.devcourse.checkmoi.domain.study.model.Study;
@@ -145,6 +145,29 @@ class StudyValidatorImplTest {
 
             assertThatExceptionOfType(StudyMemberFullException.class)
                 .isThrownBy(() -> studyValidator.validateFullMemberStudy(memberFullStudy));
+        }
+    }
+
+
+    @Nested
+    @DisplayName("유저가 현재 참가한 스터디수가 최대치에 도달했을 경우 #223")
+    class MaximumJoinStudyTest {
+
+        @Test
+        @DisplayName("S 유저가 현재 참가한 스터디수가 최대치에 도달하지 않았을 경우 정상 종료")
+        void notFullMemberStudy() {
+            int joinStudy = 1;
+
+            studyValidator.validateMaximumJoinStudy(joinStudy);
+        }
+
+        @Test
+        @DisplayName("현재 인원이 최대인원에 도달했을 경우 예외 발생")
+        void FullMemberStudy() {
+            int maxJoinStudy = 10;
+
+            assertThatExceptionOfType(StudyJoinMaximumReachedException.class)
+                .isThrownBy(() -> studyValidator.validateMaximumJoinStudy(maxJoinStudy));
         }
     }
 }

--- a/src/test/java/com/devcourse/checkmoi/domain/user/repository/CustomUserRepositoryImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/user/repository/CustomUserRepositoryImplTest.java
@@ -1,0 +1,69 @@
+package com.devcourse.checkmoi.domain.user.repository;
+
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeBook;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudy;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudyMember;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import com.devcourse.checkmoi.domain.book.model.Book;
+import com.devcourse.checkmoi.domain.book.repository.BookRepository;
+import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.model.StudyMember;
+import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
+import com.devcourse.checkmoi.domain.study.model.StudyStatus;
+import com.devcourse.checkmoi.domain.study.repository.StudyMemberRepository;
+import com.devcourse.checkmoi.domain.study.repository.StudyRepository;
+import com.devcourse.checkmoi.domain.user.model.User;
+import com.devcourse.checkmoi.template.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+
+class CustomUserRepositoryImplTest extends RepositoryTest {
+
+    @Autowired
+    BookRepository bookRepository;
+
+    @Autowired
+    StudyRepository studyRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    StudyMemberRepository studyMemberRepository;
+
+    @Nested
+    @DisplayName("유저의 스터디 개수 조회 #223")
+    class UserJoinedStudiesTest {
+
+        User user;
+
+        @BeforeEach
+        void setUp() {
+            Book book = makeBook();
+            bookRepository.save(book);
+
+            user = makeUser();
+            userRepository.save(user);
+
+            Study study = makeStudy(book, StudyStatus.RECRUITING);
+            studyRepository.save(study);
+
+            StudyMember studyMember = makeStudyMember(study, user, StudyMemberStatus.OWNED);
+            studyMemberRepository.save(studyMember);
+        }
+
+        @Test
+        @DisplayName("S 유저가 현재 참여하고 있는 스터디 개수를 반환한다.")
+        void userJoinedStudies() {
+            int want = 1;
+            int got = userRepository.userJoinedStudies(user.getId());
+
+            assertThat(got).isEqualTo(want);
+        }
+    }
+}

--- a/src/test/java/com/devcourse/checkmoi/domain/user/service/UserQueryServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/user/service/UserQueryServiceImplTest.java
@@ -1,0 +1,40 @@
+package com.devcourse.checkmoi.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import com.devcourse.checkmoi.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserQueryServiceImplTest {
+
+    @InjectMocks
+    UserQueryServiceImpl userQueryService;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Nested
+    @DisplayName("유저의 스터디 참여 수 확인 #223")
+    class UserJoinedStudiesTest {
+
+        @Test
+        @DisplayName("유저의 스터디 참여 수 확인")
+        void userJoinedStudies() {
+            Long userId = 1L;
+            int want = 1;
+            given(userRepository.userJoinedStudies(userId))
+                .willReturn(want);
+
+            int got = userQueryService.userJoinedStudies(userId);
+
+            assertThat(got).isEqualTo(want);
+        }
+    }
+ }

--- a/src/test/java/com/devcourse/checkmoi/domain/user/service/UserQueryServiceImplTest.java
+++ b/src/test/java/com/devcourse/checkmoi/domain/user/service/UserQueryServiceImplTest.java
@@ -32,7 +32,7 @@ class UserQueryServiceImplTest {
             given(userRepository.userJoinedStudies(userId))
                 .willReturn(want);
 
-            int got = userQueryService.userJoinedStudies(userId);
+            int got = userQueryService.getUserJoinedStudies(userId);
 
             assertThat(got).isEqualTo(want);
         }


### PR DESCRIPTION
## 작업사항

- facade 패턴을 적용하여 유저의 스터디 수를 유저 서비스에게 가져오도록 수정
- 최대 스터디수 (10명) 만큼 가입했을 경우 예외 발생
- 신청 후 사용자가 스터디가 10개 넘었을 때 승인시 예외 발생하도록 변경
- 해당 예외시 발생하는 exception class 추가
- 이에 따른 테스트 코드 수정
<img width="1298" alt="image" src="https://user-images.githubusercontent.com/41960243/184509487-5e30e4b1-cdbf-4a82-a68e-887c5940a0fc.png">

- resolves #223 
