### PR TITLE
🐛 fix : 댓글 조회시 순서가 뒤죽박죽으로 조회되는 현상 해결

### DIFF
--- a/src/main/java/com/devcourse/checkmoi/domain/comment/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/comment/repository/CustomCommentRepositoryImpl.java
@@ -6,7 +6,6 @@ import com.devcourse.checkmoi.domain.comment.dto.CommentResponse.CommentInfo;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQuery;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +38,8 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
             .from(comment)
             .where(
                 eqPostId(request.postId())
-            );
+            )
+            .orderBy(comment.createdAt.asc());
         long totalCount = query.fetchCount();
         List<CommentInfo> comments = query
             .offset(pageable.getOffset())


### PR DESCRIPTION
## 작업사항

- 여러명의 유저가 댓글을 작성시 일정 개수가 넘어져서 결과가 댓글 작성순이 아닌 뒤죽박죽 섞여서 나오는 현상이 발생
- 값을 DB에 조회할때 orderby를 통해 댓글 최신 작성순으로 정렬하도록 로직 추가

- resolves #244 
