### PR TITLE
✨ feat : 스케줄러 동작 api 추가 (#252)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'com.devcourse'
-version = '3.0.0'
+version = '3.1.0'
 sourceCompatibility = '17'
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,7 @@ jacocoTestCoverageVerification {
                     "com.devcourse.checkmoi.domain.*.model.vo.Q*",
                     "com.devcourse.checkmoi.domain.token.*",
                     "com.devcourse.checkmoi.domain.user.*",
+                    "com.devcourse.checkmoi.domain.study.api.Schedule*",
                     "com.devcourse.checkmoi.global.*",
             ]
         }
@@ -148,6 +149,7 @@ sonarqube {
                 """
                 src/main/java/com/devcourse/checkmoi/global/**,
                 src/main/java/com/devcourse/checkmoi/domain/user/api/AuthApi.java,
+                src/main/java/com/devcourse/checkmoi/domain/study/api/ScheduleApi.java,
                 src/main/java/com/devcourse/checkmoi/domain/token/**
                 """
     }

--- a/src/main/java/com/devcourse/checkmoi/domain/study/api/ScheduleApi.java
+++ b/src/main/java/com/devcourse/checkmoi/domain/study/api/ScheduleApi.java
@@ -1,11 +1,9 @@
 package com.devcourse.checkmoi.domain.study.api;
 
-import com.devcourse.checkmoi.domain.study.model.StudyMemberStatus;
-import com.devcourse.checkmoi.domain.study.model.StudyStatus;
-import com.devcourse.checkmoi.global.scheduler.ScheduleManager;
+import com.devcourse.checkmoi.global.scheduler.Scheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,63 +13,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ScheduleApi {
 
-    private final static String message = "[Scheduler API] : ";
+    private final Scheduler scheduler;
 
-    private final ScheduleManager scheduleService;
-
-    @GetMapping("/in-progress")
+    @PatchMapping("/in-progress")
     public void changeToInProgress() {
-        log.info(message + " 스터디 상태 변경 작업 (-> 진행 중 ) 시작");
-
-        try {
-            progressStudies();
-        } catch (Exception e) {
-            log.error(message + "[ERROR] : 스터디를 진행중 상태로 변경하는 스케줄링 작업 실패", e);
-        }
-
-        log.info(message + " 스터디 상태 변경 작업 완료!!");
+        scheduler.changeStudyAsInProgress();
     }
 
-    @GetMapping("/finished")
+    @PatchMapping("/finished")
     public void changeToFinished() {
-        log.info(message + " 스터디 상태 변경 작업 (-> 진행 완료 ) 시작");
-
-        try {
-            completeStudies();
-        } catch (Exception e) {
-            log.error(message + "[ERROR] : 스터디를 진행완료 상태로 변경하는 스케줄링 작업 실패", e);
-        }
-
-        log.info(message + " 스터디 상태 변경 작업 완료!!");
-    }
-
-    private void progressStudies() {
-        scheduleService.getAllStudiesToBeProcessed(StudyStatus.IN_PROGRESS).studies()
-            .forEach(studyId -> updateStudyWithMembers(studyId, StudyStatus.IN_PROGRESS,
-                StudyMemberStatus.DENIED));
-    }
-
-    private void completeStudies() {
-        scheduleService.getAllStudiesToBeProcessed(StudyStatus.FINISHED).studies()
-            .forEach(studyId -> updateStudy(studyId, StudyStatus.FINISHED));
-    }
-
-    private void updateStudyWithMembers(Long studyId, StudyStatus studyStatus,
-        StudyMemberStatus memberStatus) {
-        try {
-            scheduleService.updateStudyWithMembers(studyId, studyStatus, memberStatus);
-        } catch (Exception e) {
-            log.error(
-                message + "[ERROR] : 스터디를 진행중 상태로 변경하는 스케줄링 작업 실패 - 실패한 studyId : " + studyId);
-        }
-    }
-
-    private void updateStudy(Long studyId, StudyStatus studyStatus) {
-        try {
-            scheduleService.updateStudy(studyId, studyStatus);
-        } catch (Exception e) {
-            log.error(
-                message + "[ERROR] : 스터디를 진행완료 상태로 변경하는 스케줄링 작업 실패 - 실패한 studyId : " + studyId);
-        }
+        scheduler.changeStudyAsFinished();
     }
 }

--- a/src/main/java/com/devcourse/checkmoi/global/scheduler/Scheduler.java
+++ b/src/main/java/com/devcourse/checkmoi/global/scheduler/Scheduler.java
@@ -19,7 +19,7 @@ public class Scheduler {
     }
 
     @Scheduled(cron = "0 0 * * * *")
-    void changeStudyAsInProgress() {
+    public void changeStudyAsInProgress() {
         log.info(message + " 스터디 상태 변경 작업 (-> 진행 중 ) 시작");
 
         try {
@@ -32,7 +32,7 @@ public class Scheduler {
     }
 
     @Scheduled(cron = "0 0 * * * *")
-    void changeStudyAsFinished() {
+    public void changeStudyAsFinished() {
         log.info(message + " 스터디 상태 변경 작업 (-> 진행 완료 ) 시작");
 
         try {

--- a/src/test/java/com/devcourse/checkmoi/global/scheduler/SchedulerTest.java
+++ b/src/test/java/com/devcourse/checkmoi/global/scheduler/SchedulerTest.java
@@ -86,8 +86,8 @@ class SchedulerTest {
             .getStudyApplicants(study.getId())
             .members();
 
-        Assertions.assertThat(appliers.isEmpty())
-            .isTrue();
+        Assertions.assertThat(appliers)
+            .isEmpty();
     }
 
 

--- a/src/test/java/com/devcourse/checkmoi/global/scheduler/SchedulerTest.java
+++ b/src/test/java/com/devcourse/checkmoi/global/scheduler/SchedulerTest.java
@@ -1,0 +1,112 @@
+package com.devcourse.checkmoi.global.scheduler;
+
+import static com.devcourse.checkmoi.domain.study.model.StudyMemberStatus.ACCEPTED;
+import static com.devcourse.checkmoi.domain.study.model.StudyMemberStatus.OWNED;
+import static com.devcourse.checkmoi.domain.study.model.StudyMemberStatus.PENDING;
+import static com.devcourse.checkmoi.domain.study.model.StudyStatus.FINISHED;
+import static com.devcourse.checkmoi.domain.study.model.StudyStatus.IN_PROGRESS;
+import static com.devcourse.checkmoi.domain.study.model.StudyStatus.RECRUITING_FINISHED;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeBook;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudyMember;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeStudyWithStudyDate;
+import static com.devcourse.checkmoi.util.EntityGeneratorUtil.makeUser;
+import com.devcourse.checkmoi.domain.book.model.Book;
+import com.devcourse.checkmoi.domain.book.repository.BookRepository;
+import com.devcourse.checkmoi.domain.study.dto.StudyResponse.StudyMemberInfo;
+import com.devcourse.checkmoi.domain.study.model.Study;
+import com.devcourse.checkmoi.domain.study.repository.StudyMemberRepository;
+import com.devcourse.checkmoi.domain.study.repository.StudyRepository;
+import com.devcourse.checkmoi.domain.user.model.User;
+import com.devcourse.checkmoi.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+class SchedulerTest {
+
+    @Autowired
+    private StudyRepository studyRepository;
+
+    @Autowired
+    private StudyMemberRepository studyMemberRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private Scheduler scheduler;
+
+    private User owner;
+
+    private User acceptedUser;
+
+    private Book book;
+
+    @BeforeEach
+    void setUp() {
+        owner = userRepository.save(makeUser());
+        acceptedUser = userRepository.save(makeUser());
+
+        book = bookRepository.save(makeBook());
+    }
+
+    @AfterEach
+    void tearDown() {
+        studyMemberRepository.deleteAllInBatch();
+        studyRepository.deleteAllInBatch();
+        bookRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("S 스터디 진행날짜가 도래한 스터디의 상태를 진행중으로 변경하며 해당 스터디에 대해 PENDING 상태던 스터디들을 DENIED 로 변경한다")
+    @Transactional
+    void denySuccess() {
+        User pendingUser = userRepository.save(makeUser());
+        Study study = studyRepository.save(makeStudyWithStudyDate(book, RECRUITING_FINISHED,
+            LocalDate.now(), LocalDate.now().plusDays(2)));
+
+        studyMemberRepository.save(makeStudyMember(study, pendingUser, PENDING));
+        studyMemberRepository.save(makeStudyMember(study, owner, OWNED));
+        studyMemberRepository.save(makeStudyMember(study, acceptedUser, ACCEPTED));
+
+        scheduler.changeStudyAsInProgress();
+
+        List<StudyMemberInfo> appliers = studyRepository
+            .getStudyApplicants(study.getId())
+            .members();
+
+        Assertions.assertThat(appliers.isEmpty())
+            .isTrue();
+    }
+
+
+    @Test
+    @DisplayName("S 스터디 종료날짜가 도래한 스터디의 상태를 진행 완료로 변경한다")
+    void updateSuccess() {
+        Study study = studyRepository.save(makeStudyWithStudyDate(book, IN_PROGRESS,
+            LocalDate.now().minusDays(2), LocalDate.now().minusDays(1)));
+
+        studyMemberRepository.save(makeStudyMember(study, owner, OWNED));
+        studyMemberRepository.save(makeStudyMember(study, acceptedUser, ACCEPTED));
+
+        scheduler.changeStudyAsFinished();
+        studyRepository.flush();
+
+        Study foundStudy = studyRepository.findById(study.getId()).get();
+
+        Assertions.assertThat(foundStudy.getStatus())
+            .isEqualTo(FINISHED);
+    }
+
+}


### PR DESCRIPTION
## 작업사항

- 스케줄러의 동작을 api 를 통해 호출할 수 있도록 추가


## 중점적으로 봐야할 부분
- 3.1.0 으로 버전 업그레이드
- 스케줄러의 메소드들은 private-package 로 유지하고 , 일시적으로 허용해 놓는 스케줄러 동작을 시연하는 api 이므로 scheduler 와 동일한 로직이지만 따로 작성하였습니다. 

- resolves #252 
